### PR TITLE
Integração CRUD Pessoa - frontent + backend

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'views/aluno_list/aluno_list_page.dart';
+import 'views/pessoa_list/pessoa_list_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,7 +12,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: AlunoListPage(),
+      home: PessoaListPage(),
     );
   }
 }

--- a/frontend/lib/models/pessoa.dart
+++ b/frontend/lib/models/pessoa.dart
@@ -1,0 +1,19 @@
+class Pessoa {
+  final String cpf;
+  final String nome;
+  final String? comum;
+
+  Pessoa({
+    required this.cpf,
+    required this.nome,
+    this.comum,
+  });
+
+  factory Pessoa.fromJson(Map<String, dynamic> json) {
+    return Pessoa(
+      cpf: json['cpf'],
+      nome: json['nome'] ?? '',
+      comum: json['comum'],
+    );
+  }
+}

--- a/frontend/lib/services/pessoa_service.dart
+++ b/frontend/lib/services/pessoa_service.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/pessoa.dart';
+
+class PessoaService {
+  static const String baseUrl = 'http://localhost:8080';
+
+  Future<List<Pessoa>> getPessoas() async {
+    final response = await http.get(Uri.parse('$baseUrl/pessoas'));
+
+    if (response.statusCode != 200) {
+      throw Exception('Erro ao buscar pessoas: ${response.statusCode}');
+    }
+
+    final List data = jsonDecode(response.body);
+    return data.map((e) => Pessoa.fromJson(e)).toList();
+  }
+
+  Future<Pessoa> getPessoaByCpf(String cpf) async {
+    final response = await http.get(Uri.parse('$baseUrl/pessoas/$cpf'));
+
+    if (response.statusCode != 200) {
+      throw Exception('Erro ao buscar pessoa: ${response.statusCode}');
+    }
+
+    final data = jsonDecode(response.body);
+    return Pessoa.fromJson(data);
+  }
+
+  Future<void> criarPessoa({
+    required String cpf,
+    required String nome,
+    required int comumId,
+  }) async {
+    final body = {
+      "cpf": cpf,
+      "nome": nome,
+      "comum": {
+        "id": comumId,
+      }
+    };
+
+    final response = await http.post(
+      Uri.parse('$baseUrl/pessoas'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(body),
+    );
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw Exception(
+        'Erro ao criar pessoa: ${response.statusCode} - ${response.body}',
+      );
+    }
+  }
+
+  Future<void> editarPessoa({
+    required String cpf,
+    required String nome,
+    required int comumId,
+  }) async {
+    final body = {
+      "cpf": cpf,
+      "nome": nome,
+      "comum": {
+        "id": comumId,
+      }
+    };
+
+    final response = await http.put(
+      Uri.parse('$baseUrl/pessoas/$cpf'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(body),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Erro ao editar pessoa: ${response.statusCode} - ${response.body}',
+      );
+    }
+  }
+
+  Future<void> deletarPessoa(String cpf) async {
+    final response = await http.delete(Uri.parse('$baseUrl/pessoas/$cpf'));
+
+    if (response.statusCode != 200 && response.statusCode != 204) {
+      throw Exception(
+        'Erro ao excluir pessoa: ${response.statusCode} - ${response.body}',
+      );
+    }
+  }
+}

--- a/frontend/lib/views/pessoa_form/pessoa_form_page.dart
+++ b/frontend/lib/views/pessoa_form/pessoa_form_page.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import '../../models/comum.dart';
+import '../../models/pessoa.dart';
+import '../../services/aluno_service.dart';
+import '../../services/pessoa_service.dart';
+
+class PessoaFormPage extends StatefulWidget {
+  final Pessoa? pessoa;
+
+  const PessoaFormPage({super.key, this.pessoa});
+
+  @override
+  State<PessoaFormPage> createState() => _PessoaFormPageState();
+}
+
+class _PessoaFormPageState extends State<PessoaFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  final PessoaService pessoaService = PessoaService();
+  final AlunoService alunoService = AlunoService();
+
+  final TextEditingController nomeController = TextEditingController();
+  final TextEditingController cpfController = TextEditingController();
+
+  List<Comum> comuns = [];
+  int? comumSelecionadaId;
+
+  bool loading = true;
+  bool salvando = false;
+  String? erro;
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (widget.pessoa != null) {
+      nomeController.text = widget.pessoa!.nome;
+      cpfController.text = widget.pessoa!.cpf;
+    }
+
+    carregarComuns();
+  }
+
+  Future<void> carregarComuns() async {
+    try {
+      final lista = await alunoService.getComuns();
+
+      int? comumIdEncontrada;
+      if (widget.pessoa?.comum != null) {
+        final match = lista.where((c) => c.nome == widget.pessoa!.comum).toList();
+        if (match.isNotEmpty) {
+          comumIdEncontrada = match.first.id;
+        }
+      }
+
+      setState(() {
+        comuns = lista;
+        comumSelecionadaId = comumIdEncontrada;
+        loading = false;
+      });
+    } catch (e) {
+      setState(() {
+        erro = e.toString();
+        loading = false;
+      });
+    }
+  }
+
+  Future<void> salvar() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    if (comumSelecionadaId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Selecione uma comum')),
+      );
+      return;
+    }
+
+    setState(() {
+      salvando = true;
+    });
+
+    try {
+      if (widget.pessoa == null) {
+        await pessoaService.criarPessoa(
+          cpf: cpfController.text.trim(),
+          nome: nomeController.text.trim(),
+          comumId: comumSelecionadaId!,
+        );
+      } else {
+        await pessoaService.editarPessoa(
+          cpf: cpfController.text.trim(),
+          nome: nomeController.text.trim(),
+          comumId: comumSelecionadaId!,
+        );
+      }
+
+      if (!mounted) return;
+      Navigator.pop(context, true);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erro ao salvar: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          salvando = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEdicao = widget.pessoa != null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEdicao ? 'Editar Pessoa' : 'Cadastrar Pessoa'),
+      ),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : erro != null
+              ? Center(child: Text('Erro ao carregar comuns: $erro'))
+              : Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Form(
+                    key: _formKey,
+                    child: ListView(
+                      children: [
+                        TextFormField(
+                          controller: nomeController,
+                          decoration: const InputDecoration(
+                            labelText: 'Nome',
+                            border: OutlineInputBorder(),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Informe o nome';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        TextFormField(
+                          controller: cpfController,
+                          decoration: const InputDecoration(
+                            labelText: 'CPF',
+                            border: OutlineInputBorder(),
+                          ),
+                          readOnly: isEdicao,
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Informe o CPF';
+                            }
+                            if (value.trim().length != 11) {
+                              return 'CPF deve ter 11 dígitos';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        DropdownButtonFormField<int>(
+                          value: comumSelecionadaId,
+                          decoration: const InputDecoration(
+                            labelText: 'Comum',
+                            border: OutlineInputBorder(),
+                          ),
+                          items: comuns.map((comum) {
+                            return DropdownMenuItem<int>(
+                              value: comum.id,
+                              child: Text(comum.nome),
+                            );
+                          }).toList(),
+                          onChanged: (value) {
+                            setState(() {
+                              comumSelecionadaId = value;
+                            });
+                          },
+                          validator: (value) {
+                            if (value == null) {
+                              return 'Selecione uma comum';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 24),
+                        ElevatedButton(
+                          onPressed: salvando ? null : salvar,
+                          child: Text(
+                            salvando
+                                ? 'Salvando...'
+                                : (isEdicao ? 'Salvar alterações' : 'Cadastrar'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+    );
+  }
+}

--- a/frontend/lib/views/pessoa_list/pessoa_list_page.dart
+++ b/frontend/lib/views/pessoa_list/pessoa_list_page.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import '../../models/pessoa.dart';
+import '../../services/pessoa_service.dart';
+import '../pessoa_form/pessoa_form_page.dart';
+
+class PessoaListPage extends StatefulWidget {
+  const PessoaListPage({super.key});
+
+  @override
+  State<PessoaListPage> createState() => _PessoaListPageState();
+}
+
+class _PessoaListPageState extends State<PessoaListPage> {
+  final PessoaService service = PessoaService();
+
+  List<Pessoa> pessoas = [];
+  List<Pessoa> pessoasFiltradas = [];
+  bool loading = true;
+  String? erro;
+
+  @override
+  void initState() {
+    super.initState();
+    carregarPessoas();
+  }
+
+  Future<void> carregarPessoas() async {
+    setState(() {
+      loading = true;
+      erro = null;
+    });
+
+    try {
+      final lista = await service.getPessoas();
+      setState(() {
+        pessoas = lista;
+        pessoasFiltradas = lista;
+        loading = false;
+      });
+    } catch (e) {
+      setState(() {
+        erro = e.toString();
+        loading = false;
+      });
+    }
+  }
+
+  void filtrarPessoas(String texto) {
+    final resultado = pessoas.where((pessoa) {
+      return pessoa.nome.toLowerCase().contains(texto.toLowerCase()) ||
+          pessoa.cpf.contains(texto);
+    }).toList();
+
+    setState(() {
+      pessoasFiltradas = resultado;
+    });
+  }
+
+  Future<void> adicionarPessoa() async {
+    final resultado = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const PessoaFormPage(),
+      ),
+    );
+
+    if (resultado == true) {
+      carregarPessoas();
+    }
+  }
+
+  Future<void> editarPessoa(Pessoa pessoa) async {
+    try {
+      final pessoaCompleta = await service.getPessoaByCpf(pessoa.cpf);
+
+      if (!context.mounted) return;
+
+      final resultado = await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => PessoaFormPage(pessoa: pessoaCompleta),
+        ),
+      );
+
+      if (resultado == true) {
+        carregarPessoas();
+      }
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erro ao carregar pessoa: $e')),
+      );
+    }
+  }
+
+  Future<void> confirmarExclusao(Pessoa pessoa) async {
+    final confirmar = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Excluir pessoa'),
+          content: Text('Deseja excluir a pessoa ${pessoa.nome}?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancelar'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Excluir'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmar == true) {
+      try {
+        await service.deletarPessoa(pessoa.cpf);
+        await carregarPessoas();
+
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Pessoa excluída com sucesso.')),
+        );
+      } catch (e) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Não foi possível excluir a pessoa. Ela pode estar vinculada a um aluno.',
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pessoas'),
+        actions: [
+          IconButton(
+            onPressed: carregarPessoas,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Atualizar',
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: adicionarPessoa,
+        child: const Icon(Icons.add),
+      ),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : erro != null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Text(
+                      'Erro ao carregar pessoas:\n$erro',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+              : Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: TextField(
+                        decoration: const InputDecoration(
+                          hintText: 'Buscar pessoa...',
+                          border: OutlineInputBorder(),
+                          prefixIcon: Icon(Icons.search),
+                        ),
+                        onChanged: filtrarPessoas,
+                      ),
+                    ),
+                    Expanded(
+                      child: pessoas.isEmpty
+                          ? const Center(
+                              child: Text(
+                                'Nenhuma pessoa cadastrada.',
+                                style: TextStyle(fontSize: 16),
+                              ),
+                            )
+                          : pessoasFiltradas.isEmpty
+                              ? const Center(
+                                  child: Text(
+                                    'Nenhuma pessoa encontrada na busca.',
+                                    style: TextStyle(fontSize: 16),
+                                  ),
+                                )
+                              : ListView.separated(
+                                  itemCount: pessoasFiltradas.length,
+                                  separatorBuilder: (_, __) =>
+                                      const Divider(height: 1),
+                                  itemBuilder: (context, index) {
+                                    final pessoa = pessoasFiltradas[index];
+
+                                    return ListTile(
+                                      leading: CircleAvatar(
+                                        child: Text(
+                                          pessoa.nome.isNotEmpty
+                                              ? pessoa.nome[0].toUpperCase()
+                                              : '?',
+                                        ),
+                                      ),
+                                      title: Text(pessoa.nome),
+                                      subtitle: Text(
+                                        '${pessoa.cpf}\n${pessoa.comum ?? 'Sem comum'}',
+                                      ),
+                                      isThreeLine: true,
+                                      onTap: () => editarPessoa(pessoa),
+                                      trailing: IconButton(
+                                        icon: const Icon(Icons.delete),
+                                        onPressed: () => confirmarExclusao(pessoa),
+                                      ),
+                                    );
+                                  },
+                                ),
+                    ),
+                  ],
+                ),
+    );
+  }
+}


### PR DESCRIPTION
Integração CRUD Pessoa completa, incluindo a criação do frontend para CRUD Pessoa. Agora é possível: 
- abrir tela de pessoas
- listar pessoas
- buscar por nome/cpf
- cadastrar pessoa
- editar pessoa
- excluir uma pessoa que não esteja ligada a aluno
- testar exclusão de uma pessoa ligada a aluno para ver a mensagem amigável

Closes #35 