### PR TITLE
feat: adiciona perfil de admin e reforça validações de relacionamentos

### DIFF
--- a/backend/src/main/java/com/gem/backend/config/DataSeeder.java
+++ b/backend/src/main/java/com/gem/backend/config/DataSeeder.java
@@ -3,11 +3,19 @@ package com.gem.backend.config;
 import com.gem.backend.model.Admin;
 import com.gem.backend.model.Aluno;
 import com.gem.backend.model.Comum;
+import com.gem.backend.model.Instrumento;
+import com.gem.backend.model.Instrutor;
+import com.gem.backend.model.Metodo;
 import com.gem.backend.model.Pessoa;
+import com.gem.backend.model.RegistroAula;
 import com.gem.backend.repository.AdminRepository;
 import com.gem.backend.repository.AlunoRepository;
 import com.gem.backend.repository.ComumRepository;
+import com.gem.backend.repository.InstrumentoRepository;
+import com.gem.backend.repository.InstrutorRepository;
+import com.gem.backend.repository.MetodoRepository;
 import com.gem.backend.repository.PessoaRepository;
+import com.gem.backend.repository.RegistroAulaRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
@@ -15,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Configuration
@@ -28,10 +37,21 @@ public class DataSeeder {
             ComumRepository comumRepository,
             PessoaRepository pessoaRepository,
             AlunoRepository alunoRepository,
-            AdminRepository adminRepository
+            AdminRepository adminRepository,
+            InstrutorRepository instrutorRepository,
+            InstrumentoRepository instrumentoRepository,
+            MetodoRepository metodoRepository,
+            RegistroAulaRepository registroAulaRepository
     ) {
         return args -> {
-            if (comumRepository.count() > 0 || pessoaRepository.count() > 0 || alunoRepository.count() > 0 || adminRepository.count() > 0) {
+            if (comumRepository.count() > 0
+                    || pessoaRepository.count() > 0
+                    || alunoRepository.count() > 0
+                    || adminRepository.count() > 0
+                    || instrutorRepository.count() > 0
+                    || instrumentoRepository.count() > 0
+                    || metodoRepository.count() > 0
+                    || registroAulaRepository.count() > 0) {
                 logger.info("Seed ignorada: banco já possui dados.");
                 return;
             }
@@ -56,22 +76,105 @@ public class DataSeeder {
 
             comumRepository.saveAll(List.of(comumCentral, comumJardim));
 
-            Pessoa pessoa1 = criarPessoa("11111111111", "João da Silva", comumCentral);
-            Pessoa pessoa2 = criarPessoa("22222222222", "Maria Oliveira", comumCentral);
-            Pessoa pessoa3 = criarPessoa("33333333333", "Pedro Santos", comumJardim);
+            Pessoa pessoaAluno1 = criarPessoa("11111111111", "João da Silva", comumCentral);
+            Pessoa pessoaAluno2 = criarPessoa("22222222222", "Maria Oliveira", comumCentral);
+            Pessoa pessoaAluno3 = criarPessoa("33333333333", "Pedro Santos", comumJardim);
+
+            Pessoa pessoaInstrutor1 = criarPessoa("44444444444", "Carlos Instrutor", comumCentral);
+            Pessoa pessoaInstrutor2 = criarPessoa("55555555555", "Ana Instrutora", comumJardim);
+
             Pessoa pessoaAdmin = criarPessoa("00000000001", "Administrador GEM", comumCentral);
 
-            pessoaRepository.saveAll(List.of(pessoa1, pessoa2, pessoa3, pessoaAdmin));
+            pessoaRepository.saveAll(List.of(
+                    pessoaAluno1,
+                    pessoaAluno2,
+                    pessoaAluno3,
+                    pessoaInstrutor1,
+                    pessoaInstrutor2,
+                    pessoaAdmin
+            ));
 
-            Aluno aluno1 = criarAluno("senha123", pessoa1, comumCentral);
-            Aluno aluno2 = criarAluno("senha123", pessoa2, comumCentral);
-            Aluno aluno3 = criarAluno("senha123", pessoa3, comumJardim);
+            Aluno aluno1 = criarAluno("senha123", pessoaAluno1, comumCentral);
+            Aluno aluno2 = criarAluno("senha123", pessoaAluno2, comumCentral);
+            Aluno aluno3 = criarAluno("senha123", pessoaAluno3, comumJardim);
+
+            alunoRepository.saveAll(List.of(aluno1, aluno2, aluno3));
+
+            Instrutor instrutor1 = criarInstrutor("senha123", pessoaInstrutor1);
+            Instrutor instrutor2 = criarInstrutor("senha123", pessoaInstrutor2);
+
+            instrutorRepository.saveAll(List.of(instrutor1, instrutor2));
 
             Admin admin = criarAdmin("admin123", pessoaAdmin);
 
             adminRepository.save(admin);
 
-            alunoRepository.saveAll(List.of(aluno1, aluno2, aluno3));
+            Instrumento violino = criarInstrumento("Violino");
+            Instrumento trompete = criarInstrumento("Trompete");
+            Instrumento saxofone = criarInstrumento("Saxofone");
+
+            instrumentoRepository.saveAll(List.of(
+                    violino,
+                    trompete,
+                    saxofone
+            ));
+
+            Metodo metodoViolinoAluno1 = criarMetodo(
+                    "Método básico de violino",
+                    violino,
+                    aluno1
+            );
+
+            Metodo metodoTrompeteAluno2 = criarMetodo(
+                    "Iniciação ao trompete",
+                    trompete,
+                    aluno2
+            );
+
+            Metodo metodoSaxofoneAluno3 = criarMetodo(
+                    "Saxofone para iniciantes",
+                    saxofone,
+                    aluno3
+            );
+
+            metodoRepository.saveAll(List.of(
+                    metodoViolinoAluno1,
+                    metodoTrompeteAluno2,
+                    metodoSaxofoneAluno3
+            ));
+
+            RegistroAula aula1 = criarRegistroAula(
+                    aluno1,
+                    instrutor1,
+                    LocalDate.now().minusDays(7),
+                    (short) 1,
+                    "Primeira aula de violino: postura, empunhadura do arco e exercícios com cordas soltas.",
+                    "Treinar cordas soltas com arco inteiro e revisar postura diante do espelho."
+            );
+
+            RegistroAula aula2 = criarRegistroAula(
+                    aluno2,
+                    instrutor1,
+                    LocalDate.now().minusDays(5),
+                    (short) 1,
+                    "Primeira aula de trompete: respiração, embocadura e emissão das primeiras notas.",
+                    "Praticar notas longas com foco em estabilidade de som e respiração."
+            );
+
+            RegistroAula aula3 = criarRegistroAula(
+                    aluno3,
+                    instrutor2,
+                    LocalDate.now().minusDays(3),
+                    (short) 1,
+                    "Primeira aula de saxofone: montagem do instrumento, postura e emissão inicial do som.",
+                    "Praticar emissão de som com boquilha e palheta, mantendo coluna de ar constante."
+            );
+
+            registroAulaRepository.saveAll(List.of(
+                    aula1,
+                    aula2,
+                    aula3
+            ));
 
             logger.info("Seed executada com sucesso.");
         };
@@ -111,10 +214,49 @@ public class DataSeeder {
         return aluno;
     }
 
+    private Instrutor criarInstrutor(String senha, Pessoa pessoa) {
+        Instrutor instrutor = new Instrutor();
+        instrutor.setSenha(senha);
+        instrutor.setPessoa(pessoa);
+        return instrutor;
+    }
+
     private Admin criarAdmin(String senha, Pessoa pessoa) {
         Admin admin = new Admin();
         admin.setSenha(senha);
         admin.setPessoa(pessoa);
         return admin;
+    }
+
+    private Instrumento criarInstrumento(String nome) {
+        Instrumento instrumento = new Instrumento();
+        instrumento.setNome(nome);
+        return instrumento;
+    }
+
+    private Metodo criarMetodo(String nome, Instrumento instrumento, Aluno aluno) {
+        Metodo metodo = new Metodo();
+        metodo.setNome(nome);
+        metodo.setInstrumento(instrumento);
+        metodo.setAluno(aluno);
+        return metodo;
+    }
+
+    private RegistroAula criarRegistroAula(
+            Aluno aluno,
+            Instrutor instrutor,
+            LocalDate data,
+            Short presente,
+            String descricao,
+            String paraProximaAula
+    ) {
+        RegistroAula registroAula = new RegistroAula();
+        registroAula.setAluno(aluno);
+        registroAula.setInstrutor(instrutor);
+        registroAula.setData(data);
+        registroAula.setPresente(presente);
+        registroAula.setDescricao(descricao);
+        registroAula.setParaProximaAula(paraProximaAula);
+        return registroAula;
     }
 }

--- a/backend/src/main/java/com/gem/backend/config/DataSeeder.java
+++ b/backend/src/main/java/com/gem/backend/config/DataSeeder.java
@@ -1,8 +1,10 @@
 package com.gem.backend.config;
 
+import com.gem.backend.model.Admin;
 import com.gem.backend.model.Aluno;
 import com.gem.backend.model.Comum;
 import com.gem.backend.model.Pessoa;
+import com.gem.backend.repository.AdminRepository;
 import com.gem.backend.repository.AlunoRepository;
 import com.gem.backend.repository.ComumRepository;
 import com.gem.backend.repository.PessoaRepository;
@@ -25,10 +27,11 @@ public class DataSeeder {
     CommandLineRunner seedDatabase(
             ComumRepository comumRepository,
             PessoaRepository pessoaRepository,
-            AlunoRepository alunoRepository
+            AlunoRepository alunoRepository,
+            AdminRepository adminRepository
     ) {
         return args -> {
-            if (comumRepository.count() > 0 || pessoaRepository.count() > 0 || alunoRepository.count() > 0) {
+            if (comumRepository.count() > 0 || pessoaRepository.count() > 0 || alunoRepository.count() > 0 || adminRepository.count() > 0) {
                 logger.info("Seed ignorada: banco já possui dados.");
                 return;
             }
@@ -56,12 +59,17 @@ public class DataSeeder {
             Pessoa pessoa1 = criarPessoa("11111111111", "João da Silva", comumCentral);
             Pessoa pessoa2 = criarPessoa("22222222222", "Maria Oliveira", comumCentral);
             Pessoa pessoa3 = criarPessoa("33333333333", "Pedro Santos", comumJardim);
+            Pessoa pessoaAdmin = criarPessoa("00000000001", "Administrador GEM", comumCentral);
 
-            pessoaRepository.saveAll(List.of(pessoa1, pessoa2, pessoa3));
+            pessoaRepository.saveAll(List.of(pessoa1, pessoa2, pessoa3, pessoaAdmin));
 
             Aluno aluno1 = criarAluno("senha123", pessoa1, comumCentral);
             Aluno aluno2 = criarAluno("senha123", pessoa2, comumCentral);
             Aluno aluno3 = criarAluno("senha123", pessoa3, comumJardim);
+
+            Admin admin = criarAdmin("admin123", pessoaAdmin);
+
+            adminRepository.save(admin);
 
             alunoRepository.saveAll(List.of(aluno1, aluno2, aluno3));
 
@@ -101,5 +109,12 @@ public class DataSeeder {
         aluno.setPessoa(pessoa);
         aluno.setComum(comum);
         return aluno;
+    }
+
+    private Admin criarAdmin(String senha, Pessoa pessoa) {
+        Admin admin = new Admin();
+        admin.setSenha(senha);
+        admin.setPessoa(pessoa);
+        return admin;
     }
 }

--- a/backend/src/main/java/com/gem/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/gem/backend/controller/AdminController.java
@@ -1,0 +1,48 @@
+package com.gem.backend.controller;
+
+import com.gem.backend.dto.AdminResponseDTO;
+import com.gem.backend.model.Admin;
+import com.gem.backend.service.AdminService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admins")
+public class AdminController {
+
+    private final AdminService service;
+
+    public AdminController(AdminService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<AdminResponseDTO> create(@Valid @RequestBody Admin admin) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.createAdmin(admin));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AdminResponseDTO>> getList() {
+        return ResponseEntity.ok(service.getListAdmin());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AdminResponseDTO> get(@PathVariable Integer id) {
+        return ResponseEntity.ok(service.getAdmin(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AdminResponseDTO> update(@PathVariable Integer id, @Valid @RequestBody Admin admin) {
+        return ResponseEntity.ok(service.updateAdmin(id, admin));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        service.deleteAdmin(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/gem/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/gem/backend/controller/AdminController.java
@@ -36,7 +36,7 @@ public class AdminController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<AdminResponseDTO> update(@PathVariable Integer id, @Valid @RequestBody Admin admin) {
+    public ResponseEntity<AdminResponseDTO> update(@PathVariable Integer id, @RequestBody Admin admin) {
         return ResponseEntity.ok(service.updateAdmin(id, admin));
     }
 

--- a/backend/src/main/java/com/gem/backend/controller/AlunoController.java
+++ b/backend/src/main/java/com/gem/backend/controller/AlunoController.java
@@ -44,7 +44,7 @@ public class AlunoController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<AlunoResponseDTO> update(@PathVariable Long id, @Valid @RequestBody Aluno aluno) {
+    public ResponseEntity<AlunoResponseDTO> update(@PathVariable Long id, @RequestBody Aluno aluno) {
         return ResponseEntity.ok(service.updateAluno(id, aluno));
     }
 

--- a/backend/src/main/java/com/gem/backend/controller/ComumController.java
+++ b/backend/src/main/java/com/gem/backend/controller/ComumController.java
@@ -44,7 +44,7 @@ public class ComumController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ComumResponseDTO> update(@PathVariable Integer id, @Valid @RequestBody Comum comum) {
+    public ResponseEntity<ComumResponseDTO> update(@PathVariable Integer id, @RequestBody Comum comum) {
         return ResponseEntity.ok(service.updateComum(id, comum));
     }
 

--- a/backend/src/main/java/com/gem/backend/controller/InstrumentoController.java
+++ b/backend/src/main/java/com/gem/backend/controller/InstrumentoController.java
@@ -39,7 +39,7 @@ public class InstrumentoController {
     }
 
     @PutMapping("/{id}")
-    public InstrumentoResponseDTO update(@PathVariable Integer id, @Valid @RequestBody Instrumento instrumento) {
+    public InstrumentoResponseDTO update(@PathVariable Integer id, @RequestBody Instrumento instrumento) {
         return new InstrumentoResponseDTO(service.updateInstrumento(id, instrumento));
     }
 

--- a/backend/src/main/java/com/gem/backend/controller/InstrutorController.java
+++ b/backend/src/main/java/com/gem/backend/controller/InstrutorController.java
@@ -39,7 +39,7 @@ public class InstrutorController {
     }
 
     @PutMapping("/{id}")
-    public InstrutorResponseDTO update(@PathVariable Integer id, @Valid @RequestBody Instrutor instrutor) {
+    public InstrutorResponseDTO update(@PathVariable Integer id, @RequestBody Instrutor instrutor) {
         return new InstrutorResponseDTO(service.updateInstrutor(id, instrutor));
     }
 

--- a/backend/src/main/java/com/gem/backend/controller/MetodoController.java
+++ b/backend/src/main/java/com/gem/backend/controller/MetodoController.java
@@ -39,7 +39,7 @@ public class MetodoController {
     }
 
     @PutMapping("/{id}")
-    public MetodoResponseDTO update(@PathVariable Integer id, @Valid @RequestBody Metodo metodo) {
+    public MetodoResponseDTO update(@PathVariable Integer id, @RequestBody Metodo metodo) {
         return new MetodoResponseDTO(service.updateMetodo(id, metodo));
     }
 

--- a/backend/src/main/java/com/gem/backend/controller/MetodoController.java
+++ b/backend/src/main/java/com/gem/backend/controller/MetodoController.java
@@ -1,19 +1,12 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package com.gem.backend.controller;
 
-/**
- *
- * @author leonardo
- */
 import com.gem.backend.dto.MetodoResponseDTO;
 import com.gem.backend.model.Metodo;
 import com.gem.backend.service.MetodoService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController

--- a/backend/src/main/java/com/gem/backend/controller/PessoaController.java
+++ b/backend/src/main/java/com/gem/backend/controller/PessoaController.java
@@ -49,7 +49,7 @@ public class PessoaController {
     @PutMapping("/{cpf}")
     public ResponseEntity<PessoaResponseDTO> update(
             @PathVariable String cpf,
-            @Valid @RequestBody Pessoa pessoa
+            @RequestBody Pessoa pessoa
     ) {
         Pessoa pessoaAtualizada = service.updatePessoa(cpf, pessoa);
         PessoaResponseDTO response = new PessoaResponseDTO(pessoaAtualizada);

--- a/backend/src/main/java/com/gem/backend/controller/RegistroAulaController.java
+++ b/backend/src/main/java/com/gem/backend/controller/RegistroAulaController.java
@@ -39,7 +39,7 @@ public class RegistroAulaController {
     }
 
     @PutMapping("/{id}")
-    public RegistroAulaResponseDTO update(@PathVariable Integer id, @Valid @RequestBody RegistroAula aula) {
+    public RegistroAulaResponseDTO update(@PathVariable Integer id, @RequestBody RegistroAula aula) {
         return new RegistroAulaResponseDTO(service.updateRegistroAula(id, aula));
     }
 

--- a/backend/src/main/java/com/gem/backend/dto/AdminResponseDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/AdminResponseDTO.java
@@ -1,0 +1,17 @@
+package com.gem.backend.dto;
+
+import com.gem.backend.model.Admin;
+
+public record AdminResponseDTO(Integer id, String cpf, String nome, String comum) {
+
+    public AdminResponseDTO(Admin admin) {
+        this(
+                admin.getId(),
+                admin.getPessoa() != null ? admin.getPessoa().getCpf() : null,
+                admin.getPessoa() != null ? admin.getPessoa().getNome() : null,
+                admin.getPessoa() != null && admin.getPessoa().getComum() != null
+                ? admin.getPessoa().getComum().getNome()
+                : null
+        );
+    }
+}

--- a/backend/src/main/java/com/gem/backend/dto/InstrutorResponseDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/InstrutorResponseDTO.java
@@ -8,15 +8,25 @@ package com.gem.backend.dto;
  *
  * @author leonardo
  */
-
 import com.gem.backend.model.Instrutor;
 
-public record InstrutorResponseDTO(Integer id, String nome, String cpf) {
+public record InstrutorResponseDTO(
+        Integer id,
+        String nome,
+        String cpf,
+        String comumNome,
+        String comumCidade,
+        String comumUF
+        ) {
+
     public InstrutorResponseDTO(Instrutor instrutor) {
         this(
-            instrutor.getId(),
-            instrutor.getPessoa() != null ? instrutor.getPessoa().getNome() : null,
-            instrutor.getPessoa() != null ? instrutor.getPessoa().getCpf() : null
+                instrutor.getId(),
+                instrutor.getPessoa() != null ? instrutor.getPessoa().getNome() : null,
+                instrutor.getPessoa() != null ? instrutor.getPessoa().getCpf() : null,
+                instrutor.getPessoa().getComum() != null ? instrutor.getPessoa().getComum().getNome() : "",
+                instrutor.getPessoa().getComum() != null ? instrutor.getPessoa().getComum().getCidade() : "",
+                instrutor.getPessoa().getComum() != null ? instrutor.getPessoa().getComum().getEstado() : ""
         );
     }
 }

--- a/backend/src/main/java/com/gem/backend/dto/PessoaResponseDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/PessoaResponseDTO.java
@@ -9,7 +9,8 @@ public record PessoaResponseDTO(
         String comumNome,
         String comumCidade,
         String comumUF
-) {
+        ) {
+
     public PessoaResponseDTO(Pessoa pessoa) {
         this(
                 pessoa.getCpf(),

--- a/backend/src/main/java/com/gem/backend/exception/BadRequestException.java
+++ b/backend/src/main/java/com/gem/backend/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.gem.backend.exception;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/gem/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gem/backend/exception/GlobalExceptionHandler.java
@@ -98,4 +98,20 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
     }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ApiError> handleBadRequest(
+            BadRequestException ex,
+            HttpServletRequest request
+    ) {
+        ApiError error = new ApiError(
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
 }

--- a/backend/src/main/java/com/gem/backend/model/Admin.java
+++ b/backend/src/main/java/com/gem/backend/model/Admin.java
@@ -2,6 +2,7 @@ package com.gem.backend.model;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Entity
@@ -17,8 +18,14 @@ public class Admin {
     @Column(length = 16, nullable = false)
     private String senha;
 
+    @NotNull(message = "Pessoa é obrigatória.")
     @OneToOne
-    @JoinColumn(name = "pessoa_cpf", referencedColumnName = "cpf")
+    @JoinColumn(
+            name = "pessoa_cpf",
+            referencedColumnName = "cpf",
+            nullable = false,
+            unique = true
+    )
     private Pessoa pessoa;
 
     public Admin() {

--- a/backend/src/main/java/com/gem/backend/model/Admin.java
+++ b/backend/src/main/java/com/gem/backend/model/Admin.java
@@ -1,0 +1,50 @@
+package com.gem.backend.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "admins")
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @NotBlank(message = "Senha é obrigatória.")
+    @Size(max = 16, message = "Senha deve ter no máximo 16 caracteres.")
+    @Column(length = 16, nullable = false)
+    private String senha;
+
+    @OneToOne
+    @JoinColumn(name = "pessoa_cpf", referencedColumnName = "cpf")
+    private Pessoa pessoa;
+
+    public Admin() {
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getSenha() {
+        return senha;
+    }
+
+    public void setSenha(String senha) {
+        this.senha = senha;
+    }
+
+    public Pessoa getPessoa() {
+        return pessoa;
+    }
+
+    public void setPessoa(Pessoa pessoa) {
+        this.pessoa = pessoa;
+    }
+}

--- a/backend/src/main/java/com/gem/backend/model/Aluno.java
+++ b/backend/src/main/java/com/gem/backend/model/Aluno.java
@@ -10,6 +10,7 @@ package com.gem.backend.model;
  */
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Entity
@@ -25,8 +26,14 @@ public class Aluno {
     @Column(nullable = false, length = 16)
     private String senha;
 
+    @NotNull(message = "Pessoa é obrigatória.")
     @OneToOne
-    @JoinColumn(name = "pessoa_cpf", referencedColumnName = "cpf")
+    @JoinColumn(
+            name = "pessoa_cpf",
+            referencedColumnName = "cpf",
+            nullable = false,
+            unique = true
+    )
     private Pessoa pessoa;
 
     @ManyToOne

--- a/backend/src/main/java/com/gem/backend/model/Instrutor.java
+++ b/backend/src/main/java/com/gem/backend/model/Instrutor.java
@@ -10,6 +10,7 @@ package com.gem.backend.model;
  */
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
@@ -26,8 +27,14 @@ public class Instrutor {
     @Column(length = 16, nullable = false)
     private String senha;
 
+    @NotNull(message = "Pessoa é obrigatória.")
     @OneToOne
-    @JoinColumn(name = "pessoa_cpf", referencedColumnName = "cpf")
+    @JoinColumn(
+            name = "pessoa_cpf",
+            referencedColumnName = "cpf",
+            nullable = false,
+            unique = true
+    )
     private Pessoa pessoa;
 
     @OneToMany(mappedBy = "instrutor")

--- a/backend/src/main/java/com/gem/backend/model/Metodo.java
+++ b/backend/src/main/java/com/gem/backend/model/Metodo.java
@@ -1,15 +1,8 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package com.gem.backend.model;
 
-/**
- *
- * @author leonardo
- */
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Entity
@@ -25,8 +18,9 @@ public class Metodo {
     @Column(nullable = false, length = 64)
     private String nome;
 
+    @NotNull(message = "Instrumento é obrigatório.")
     @ManyToOne
-    @JoinColumn(name = "instrumento_id")
+    @JoinColumn(name = "instrumento_id", nullable = false)
     private Instrumento instrumento;
 
     @ManyToOne

--- a/backend/src/main/java/com/gem/backend/model/Pessoa.java
+++ b/backend/src/main/java/com/gem/backend/model/Pessoa.java
@@ -10,6 +10,7 @@ package com.gem.backend.model;
  */
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Pattern;
 
@@ -28,8 +29,9 @@ public class Pessoa {
     @Column(length = 64, nullable = false)
     private String nome;
 
+    @NotNull(message = "Comum é obrigatória.")
     @ManyToOne
-    @JoinColumn(name = "id_comum", referencedColumnName = "id")
+    @JoinColumn(name = "id_comum", referencedColumnName = "id", nullable = false)
     private Comum comum;
 
     public Pessoa() {

--- a/backend/src/main/java/com/gem/backend/model/RegistroAula.java
+++ b/backend/src/main/java/com/gem/backend/model/RegistroAula.java
@@ -3,6 +3,7 @@ package com.gem.backend.model;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
@@ -14,12 +15,14 @@ public class RegistroAula {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @NotNull(message = "Aluno é obrigatório.")
     @ManyToOne
-    @JoinColumn(name = "aluno_id")
+    @JoinColumn(name = "aluno_id", nullable = false)
     private Aluno aluno;
 
+    @NotNull(message = "Instrutor é obrigatório.")
     @ManyToOne
-    @JoinColumn(name = "instrutor_id")
+    @JoinColumn(name = "instrutor_id", nullable = false)
     private Instrutor instrutor;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/gem/backend/repository/AdminRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/AdminRepository.java
@@ -1,0 +1,9 @@
+package com.gem.backend.repository;
+
+import com.gem.backend.model.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Integer> {
+}

--- a/backend/src/main/java/com/gem/backend/repository/AdminRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/AdminRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Integer> {
+
+    boolean existsByPessoa_Cpf(String cpf);
 }

--- a/backend/src/main/java/com/gem/backend/repository/AlunoRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/AlunoRepository.java
@@ -15,4 +15,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AlunoRepository extends JpaRepository<Aluno, Long> {
 
+    boolean existsByPessoa_Cpf(String cpf);
 }

--- a/backend/src/main/java/com/gem/backend/repository/InstrutorRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/InstrutorRepository.java
@@ -8,11 +8,12 @@ package com.gem.backend.repository;
  *
  * @author leonardo
  */
-
 import com.gem.backend.model.Instrutor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InstrutorRepository extends JpaRepository<Instrutor, Integer> {
+
+    boolean existsByPessoa_Cpf(String cpf);
 }

--- a/backend/src/main/java/com/gem/backend/service/AdminService.java
+++ b/backend/src/main/java/com/gem/backend/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.gem.backend.service;
 
 import com.gem.backend.dto.AdminResponseDTO;
+import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
 import com.gem.backend.model.Admin;
@@ -27,12 +28,13 @@ public class AdminService {
             throw new DuplicateResourceException("Já existe um admin cadastrado com este ID.");
         }
 
-        if (admin.getPessoa() != null && admin.getPessoa().getCpf() != null) {
-            Pessoa pessoa = pessoaRepository.findById(admin.getPessoa().getCpf())
-                    .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+        Pessoa pessoa = buscarPessoaObrigatoria(admin);
 
-            admin.setPessoa(pessoa);
+        if (repository.existsByPessoa_Cpf(pessoa.getCpf())) {
+            throw new DuplicateResourceException("Já existe um admin cadastrado para este CPF.");
         }
+
+        admin.setPessoa(pessoa);
 
         Admin adminSalvo = repository.save(admin);
         return new AdminResponseDTO(adminSalvo);
@@ -61,8 +63,13 @@ public class AdminService {
         }
 
         if (dadosAtualizados.getPessoa() != null && dadosAtualizados.getPessoa().getCpf() != null) {
-            Pessoa pessoa = pessoaRepository.findById(dadosAtualizados.getPessoa().getCpf())
-                    .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+            Pessoa pessoa = buscarPessoaObrigatoria(dadosAtualizados);
+
+            boolean cpfMudou = !pessoa.getCpf().equals(adminExistente.getPessoa().getCpf());
+
+            if (cpfMudou && repository.existsByPessoa_Cpf(pessoa.getCpf())) {
+                throw new DuplicateResourceException("Já existe um admin cadastrado para este CPF.");
+            }
 
             adminExistente.setPessoa(pessoa);
         }
@@ -76,5 +83,16 @@ public class AdminService {
         }
 
         repository.deleteById(id);
+    }
+
+    private Pessoa buscarPessoaObrigatoria(Admin admin) {
+        if (admin.getPessoa() == null
+                || admin.getPessoa().getCpf() == null
+                || admin.getPessoa().getCpf().trim().isEmpty()) {
+            throw new BadRequestException("Informe o CPF da pessoa vinculada ao admin.");
+        }
+
+        return pessoaRepository.findById(admin.getPessoa().getCpf())
+                .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
     }
 }

--- a/backend/src/main/java/com/gem/backend/service/AdminService.java
+++ b/backend/src/main/java/com/gem/backend/service/AdminService.java
@@ -1,0 +1,80 @@
+package com.gem.backend.service;
+
+import com.gem.backend.dto.AdminResponseDTO;
+import com.gem.backend.exception.DuplicateResourceException;
+import com.gem.backend.exception.ResourceNotFoundException;
+import com.gem.backend.model.Admin;
+import com.gem.backend.model.Pessoa;
+import com.gem.backend.repository.AdminRepository;
+import com.gem.backend.repository.PessoaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AdminService {
+
+    private final AdminRepository repository;
+    private final PessoaRepository pessoaRepository;
+
+    public AdminService(AdminRepository repository, PessoaRepository pessoaRepository) {
+        this.repository = repository;
+        this.pessoaRepository = pessoaRepository;
+    }
+
+    public AdminResponseDTO createAdmin(Admin admin) {
+        if (admin.getId() != null && repository.existsById(admin.getId())) {
+            throw new DuplicateResourceException("Já existe um admin cadastrado com este ID.");
+        }
+
+        if (admin.getPessoa() != null && admin.getPessoa().getCpf() != null) {
+            Pessoa pessoa = pessoaRepository.findById(admin.getPessoa().getCpf())
+                    .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+
+            admin.setPessoa(pessoa);
+        }
+
+        Admin adminSalvo = repository.save(admin);
+        return new AdminResponseDTO(adminSalvo);
+    }
+
+    public List<AdminResponseDTO> getListAdmin() {
+        return repository.findAll()
+                .stream()
+                .map(AdminResponseDTO::new)
+                .toList();
+    }
+
+    public AdminResponseDTO getAdmin(Integer id) {
+        Admin admin = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Admin não encontrado."));
+
+        return new AdminResponseDTO(admin);
+    }
+
+    public AdminResponseDTO updateAdmin(Integer id, Admin dadosAtualizados) {
+        Admin adminExistente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Admin não encontrado."));
+
+        if (dadosAtualizados.getSenha() != null && !dadosAtualizados.getSenha().trim().isEmpty()) {
+            adminExistente.setSenha(dadosAtualizados.getSenha());
+        }
+
+        if (dadosAtualizados.getPessoa() != null && dadosAtualizados.getPessoa().getCpf() != null) {
+            Pessoa pessoa = pessoaRepository.findById(dadosAtualizados.getPessoa().getCpf())
+                    .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+
+            adminExistente.setPessoa(pessoa);
+        }
+
+        return new AdminResponseDTO(repository.save(adminExistente));
+    }
+
+    public void deleteAdmin(Integer id) {
+        if (!repository.existsById(id)) {
+            throw new ResourceNotFoundException("Admin não encontrado.");
+        }
+
+        repository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/gem/backend/service/AlunoService.java
+++ b/backend/src/main/java/com/gem/backend/service/AlunoService.java
@@ -31,18 +31,6 @@ public class AlunoService {
         this.comumRepository = comumRepository;
     }
 
-    private Pessoa buscarPessoaObrigatoria(Aluno aluno) {
-        if (aluno == null
-                || aluno.getPessoa() == null
-                || aluno.getPessoa().getCpf() == null
-                || aluno.getPessoa().getCpf().trim().isEmpty()) {
-            throw new BadRequestException("Informe o CPF da pessoa vinculada ao aluno.");
-        }
-
-        return pessoaRepository.findById(aluno.getPessoa().getCpf())
-                .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
-    }
-
     public AlunoResponseDTO createAluno(Aluno aluno) {
         if (aluno.getId() != null && repository.existsById(aluno.getId())) {
             throw new DuplicateResourceException("Já existe um aluno cadastrado com este ID.");
@@ -117,5 +105,17 @@ public class AlunoService {
         }
 
         repository.deleteById(id);
+    }
+
+    private Pessoa buscarPessoaObrigatoria(Aluno aluno) {
+        if (aluno == null
+                || aluno.getPessoa() == null
+                || aluno.getPessoa().getCpf() == null
+                || aluno.getPessoa().getCpf().trim().isEmpty()) {
+            throw new BadRequestException("Informe o CPF da pessoa vinculada ao aluno.");
+        }
+
+        return pessoaRepository.findById(aluno.getPessoa().getCpf())
+                .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
     }
 }

--- a/backend/src/main/java/com/gem/backend/service/AlunoService.java
+++ b/backend/src/main/java/com/gem/backend/service/AlunoService.java
@@ -1,6 +1,7 @@
 package com.gem.backend.service;
 
 import com.gem.backend.dto.AlunoResponseDTO;
+import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
 import com.gem.backend.model.Aluno;
@@ -30,17 +31,30 @@ public class AlunoService {
         this.comumRepository = comumRepository;
     }
 
+    private Pessoa buscarPessoaObrigatoria(Aluno aluno) {
+        if (aluno == null
+                || aluno.getPessoa() == null
+                || aluno.getPessoa().getCpf() == null
+                || aluno.getPessoa().getCpf().trim().isEmpty()) {
+            throw new BadRequestException("Informe o CPF da pessoa vinculada ao aluno.");
+        }
+
+        return pessoaRepository.findById(aluno.getPessoa().getCpf())
+                .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+    }
+
     public AlunoResponseDTO createAluno(Aluno aluno) {
         if (aluno.getId() != null && repository.existsById(aluno.getId())) {
             throw new DuplicateResourceException("Já existe um aluno cadastrado com este ID.");
         }
 
-        if (aluno.getPessoa() != null && aluno.getPessoa().getCpf() != null) {
-            Pessoa pessoa = pessoaRepository.findById(aluno.getPessoa().getCpf())
-                    .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+        Pessoa pessoa = buscarPessoaObrigatoria(aluno);
 
-            aluno.setPessoa(pessoa);
+        if (repository.existsByPessoa_Cpf(pessoa.getCpf())) {
+            throw new DuplicateResourceException("Já existe um aluno cadastrado para este CPF.");
         }
+
+        aluno.setPessoa(pessoa);
 
         if (aluno.getComum() != null && aluno.getComum().getId() != null) {
             Comum comum = comumRepository.findById(aluno.getComum().getId())
@@ -75,8 +89,14 @@ public class AlunoService {
         }
 
         if (dadosAtualizados.getPessoa() != null && dadosAtualizados.getPessoa().getCpf() != null) {
-            Pessoa pessoa = pessoaRepository.findById(dadosAtualizados.getPessoa().getCpf())
-                    .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+            Pessoa pessoa = buscarPessoaObrigatoria(dadosAtualizados);
+
+            boolean cpfMudou = alunoExistente.getPessoa() == null
+                    || !pessoa.getCpf().equals(alunoExistente.getPessoa().getCpf());
+
+            if (cpfMudou && repository.existsByPessoa_Cpf(pessoa.getCpf())) {
+                throw new DuplicateResourceException("Já existe um aluno cadastrado para este CPF.");
+            }
 
             alunoExistente.setPessoa(pessoa);
         }

--- a/backend/src/main/java/com/gem/backend/service/InstrutorService.java
+++ b/backend/src/main/java/com/gem/backend/service/InstrutorService.java
@@ -1,31 +1,39 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package com.gem.backend.service;
 
-/**
- *
- * @author leonardo
- */
+import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
 import com.gem.backend.model.Instrutor;
+import com.gem.backend.model.Pessoa;
 import com.gem.backend.repository.InstrutorRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.gem.backend.repository.PessoaRepository;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
 
 @Service
 public class InstrutorService {
 
-    @Autowired
-    private InstrutorRepository repository;
+    private final InstrutorRepository repository;
+    private final PessoaRepository pessoaRepository;
+
+    public InstrutorService(InstrutorRepository repository, PessoaRepository pessoaRepository) {
+        this.repository = repository;
+        this.pessoaRepository = pessoaRepository;
+    }
 
     public Instrutor createInstrutor(Instrutor instrutor) {
         if (instrutor.getId() != null && repository.existsById(instrutor.getId())) {
             throw new DuplicateResourceException("Já existe um instrutor cadastrado com este ID.");
         }
+
+        Pessoa pessoa = buscarPessoaObrigatoria(instrutor);
+
+        if (repository.existsByPessoa_Cpf(pessoa.getCpf())) {
+            throw new DuplicateResourceException("Já existe um instrutor cadastrado para este CPF.");
+        }
+
+        instrutor.setPessoa(pessoa);
 
         return repository.save(instrutor);
     }
@@ -36,7 +44,7 @@ public class InstrutorService {
 
     public Instrutor getInstrutor(Integer id) {
         return repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Instrutor não encontrado!"));
+                .orElseThrow(() -> new ResourceNotFoundException("Instrutor não encontrado."));
     }
 
     public Instrutor updateInstrutor(Integer id, Instrutor dadosAtualizados) {
@@ -47,7 +55,16 @@ public class InstrutorService {
         }
 
         if (dadosAtualizados.getPessoa() != null && dadosAtualizados.getPessoa().getCpf() != null) {
-            existente.setPessoa(dadosAtualizados.getPessoa());
+            Pessoa pessoa = buscarPessoaObrigatoria(dadosAtualizados);
+
+            boolean cpfMudou = existente.getPessoa() == null
+                    || !pessoa.getCpf().equals(existente.getPessoa().getCpf());
+
+            if (cpfMudou && repository.existsByPessoa_Cpf(pessoa.getCpf())) {
+                throw new DuplicateResourceException("Já existe um instrutor cadastrado para este CPF.");
+            }
+
+            existente.setPessoa(pessoa);
         }
 
         return repository.save(existente);
@@ -59,5 +76,16 @@ public class InstrutorService {
         }
 
         repository.deleteById(id);
+    }
+
+    private Pessoa buscarPessoaObrigatoria(Instrutor instrutor) {
+        if (instrutor.getPessoa() == null
+                || instrutor.getPessoa().getCpf() == null
+                || instrutor.getPessoa().getCpf().trim().isEmpty()) {
+            throw new BadRequestException("Informe o CPF da pessoa vinculada ao instrutor.");
+        }
+
+        return pessoaRepository.findById(instrutor.getPessoa().getCpf())
+                .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
     }
 }

--- a/backend/src/main/java/com/gem/backend/service/MetodoService.java
+++ b/backend/src/main/java/com/gem/backend/service/MetodoService.java
@@ -1,30 +1,46 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package com.gem.backend.service;
 
-/**
- *
- * @author leonardo
- */
+import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
+import com.gem.backend.model.Aluno;
+import com.gem.backend.model.Instrumento;
 import com.gem.backend.model.Metodo;
+import com.gem.backend.repository.AlunoRepository;
+import com.gem.backend.repository.InstrumentoRepository;
 import com.gem.backend.repository.MetodoRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
 
 @Service
 public class MetodoService {
 
-    @Autowired
-    private MetodoRepository repository;
+    private final MetodoRepository repository;
+    private final InstrumentoRepository instrumentoRepository;
+    private final AlunoRepository alunoRepository;
+
+    public MetodoService(
+            MetodoRepository repository,
+            InstrumentoRepository instrumentoRepository,
+            AlunoRepository alunoRepository
+    ) {
+        this.repository = repository;
+        this.instrumentoRepository = instrumentoRepository;
+        this.alunoRepository = alunoRepository;
+    }
 
     public Metodo createMetodo(Metodo metodo) {
         if (metodo.getId() != null && repository.existsById(metodo.getId())) {
             throw new DuplicateResourceException("Já existe um método cadastrado com este ID.");
+        }
+
+        Instrumento instrumento = buscarInstrumentoObrigatorio(metodo);
+        metodo.setInstrumento(instrumento);
+
+        if (metodo.getAluno() != null && metodo.getAluno().getId() != null) {
+            Aluno aluno = buscarAluno(metodo.getAluno().getId());
+            metodo.setAluno(aluno);
         }
 
         return repository.save(metodo);
@@ -36,7 +52,7 @@ public class MetodoService {
 
     public Metodo getMetodo(Integer id) {
         return repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Método não encontrado!"));
+                .orElseThrow(() -> new ResourceNotFoundException("Método não encontrado."));
     }
 
     public Metodo updateMetodo(Integer id, Metodo dadosAtualizados) {
@@ -46,11 +62,18 @@ public class MetodoService {
             existente.setNome(dadosAtualizados.getNome());
         }
 
-        if (dadosAtualizados.getInstrumento() != null && dadosAtualizados.getInstrumento().getId() != null) {
-            existente.setInstrumento(dadosAtualizados.getInstrumento());
+        if (dadosAtualizados.getInstrumento() != null) {
+            Instrumento instrumento = buscarInstrumentoObrigatorio(dadosAtualizados);
+            existente.setInstrumento(instrumento);
         }
-        if (dadosAtualizados.getAluno() != null && dadosAtualizados.getAluno().getId() != null) {
-            existente.setAluno(dadosAtualizados.getAluno());
+
+        if (dadosAtualizados.getAluno() != null) {
+            if (dadosAtualizados.getAluno().getId() == null) {
+                throw new BadRequestException("Informe o ID do aluno vinculado ao método.");
+            }
+
+            Aluno aluno = buscarAluno(dadosAtualizados.getAluno().getId());
+            existente.setAluno(aluno);
         }
 
         return repository.save(existente);
@@ -62,5 +85,20 @@ public class MetodoService {
         }
 
         repository.deleteById(id);
+    }
+
+    private Instrumento buscarInstrumentoObrigatorio(Metodo metodo) {
+        if (metodo.getInstrumento() == null
+                || metodo.getInstrumento().getId() == null) {
+            throw new BadRequestException("Informe o ID do instrumento vinculado ao método.");
+        }
+
+        return instrumentoRepository.findById(metodo.getInstrumento().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Instrumento não encontrado."));
+    }
+
+    private Aluno buscarAluno(Long id) {
+        return alunoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado."));
     }
 }

--- a/backend/src/main/java/com/gem/backend/service/PessoaService.java
+++ b/backend/src/main/java/com/gem/backend/service/PessoaService.java
@@ -1,5 +1,6 @@
 package com.gem.backend.service;
 
+import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
 import com.gem.backend.model.Comum;
@@ -26,12 +27,8 @@ public class PessoaService {
             throw new DuplicateResourceException("Já existe uma pessoa cadastrada com este CPF.");
         }
 
-        if (pessoa.getComum() != null && pessoa.getComum().getId() != null) {
-            Comum comum = comumRepository.findById(pessoa.getComum().getId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Comum não encontrada."));
-
-            pessoa.setComum(comum);
-        }
+        Comum comum = buscarComumObrigatoria(pessoa);
+        pessoa.setComum(comum);
 
         return repository.save(pessoa);
     }
@@ -69,5 +66,14 @@ public class PessoaService {
         }
 
         repository.deleteById(cpf);
+    }
+
+    private Comum buscarComumObrigatoria(Pessoa pessoa) {
+        if (pessoa.getComum() == null || pessoa.getComum().getId() == null) {
+            throw new BadRequestException("Informe o ID da comum vinculada à pessoa.");
+        }
+
+        return comumRepository.findById(pessoa.getComum().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Comum não encontrada."));
     }
 }

--- a/backend/src/main/java/com/gem/backend/service/RegistroAulaService.java
+++ b/backend/src/main/java/com/gem/backend/service/RegistroAulaService.java
@@ -1,10 +1,14 @@
 package com.gem.backend.service;
 
+import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
+import com.gem.backend.model.Aluno;
+import com.gem.backend.model.Instrutor;
 import com.gem.backend.model.RegistroAula;
+import com.gem.backend.repository.AlunoRepository;
+import com.gem.backend.repository.InstrutorRepository;
 import com.gem.backend.repository.RegistroAulaRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -13,19 +17,40 @@ import java.util.List;
 @Service
 public class RegistroAulaService {
 
-    @Autowired
-    private RegistroAulaRepository repository;
+    private final RegistroAulaRepository repository;
+    private final AlunoRepository alunoRepository;
+    private final InstrutorRepository instrutorRepository;
+
+    public RegistroAulaService(
+            RegistroAulaRepository repository,
+            AlunoRepository alunoRepository,
+            InstrutorRepository instrutorRepository
+    ) {
+        this.repository = repository;
+        this.alunoRepository = alunoRepository;
+        this.instrutorRepository = instrutorRepository;
+    }
 
     public RegistroAula createRegistroAula(RegistroAula aula) {
         if (aula.getId() != null && repository.existsById(aula.getId())) {
             throw new DuplicateResourceException("Já existe uma aula cadastrada com este ID.");
         }
 
+        Aluno aluno = buscarAlunoObrigatorio(aula);
+        Instrutor instrutor = buscarInstrutorObrigatorio(aula);
+
+        aula.setAluno(aluno);
+        aula.setInstrutor(instrutor);
+
         if (aula.getData() == null) {
             aula.setData(LocalDate.now());
         }
 
-        return repository.save(aula);
+        RegistroAula aulaSalva = repository.save(aula);
+        aulaSalva.setAluno(aluno);
+        aulaSalva.setInstrutor(instrutor);
+
+        return aulaSalva;
     }
 
     public List<RegistroAula> getListRegistroAula() {
@@ -40,12 +65,14 @@ public class RegistroAulaService {
     public RegistroAula updateRegistroAula(Integer id, RegistroAula dadosAtualizados) {
         RegistroAula existente = getRegistroAula(id);
 
-        if (dadosAtualizados.getAluno() != null && dadosAtualizados.getAluno().getId() != null) {
-            existente.setAluno(dadosAtualizados.getAluno());
+        if (dadosAtualizados.getAluno() != null) {
+            Aluno aluno = buscarAlunoObrigatorio(dadosAtualizados);
+            existente.setAluno(aluno);
         }
 
-        if (dadosAtualizados.getInstrutor() != null && dadosAtualizados.getInstrutor().getId() != null) {
-            existente.setInstrutor(dadosAtualizados.getInstrutor());
+        if (dadosAtualizados.getInstrutor() != null) {
+            Instrutor instrutor = buscarInstrutorObrigatorio(dadosAtualizados);
+            existente.setInstrutor(instrutor);
         }
 
         if (dadosAtualizados.getDescricao() != null) {
@@ -73,5 +100,23 @@ public class RegistroAulaService {
         }
 
         repository.deleteById(id);
+    }
+
+    private Aluno buscarAlunoObrigatorio(RegistroAula aula) {
+        if (aula.getAluno() == null || aula.getAluno().getId() == null) {
+            throw new BadRequestException("Informe o ID do aluno vinculado ao registro de aula.");
+        }
+
+        return alunoRepository.findById(aula.getAluno().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado."));
+    }
+
+    private Instrutor buscarInstrutorObrigatorio(RegistroAula aula) {
+        if (aula.getInstrutor() == null || aula.getInstrutor().getId() == null) {
+            throw new BadRequestException("Informe o ID do instrutor vinculado ao registro de aula.");
+        }
+
+        return instrutorRepository.findById(aula.getInstrutor().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Instrutor não encontrado."));
     }
 }


### PR DESCRIPTION
## O que foi feito

- Cria a entidade `Admin`, vinculada à entidade `Pessoa` por relacionamento 1:1.
- Adiciona repository, service, controller e DTO de resposta para o CRUD de admins.
- Adiciona validação para impedir múltiplos admins vinculados ao mesmo CPF.
- Adiciona `BadRequestException` e tratamento global para erros de requisição inválida.
- Reforça validações de relacionamento em entidades que dependem de outras entidades:
  - `Aluno`
  - `Instrutor`
  - `Metodo`
  - `RegistroAula`
  - `Pessoa`
- Garante que os services busquem entidades relacionadas reais no banco antes de salvar ou atualizar registros.
- Ajusta controllers para permitir updates parciais onde necessário.
- Atualiza a seed de desenvolvimento com dados para:
  - comuns
  - pessoas
  - alunos
  - instrutores
  - admin
  - instrumentos
  - métodos
  - registros de aula

Closes #59 