### PR TITLE
feat: dockeriza o frontend da aplicação

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,40 @@
 
 Sistema desenvolvido para a disciplina de Projeto Integrador, com o objetivo de auxiliar no controle de instrutores, alunos, aulas e acompanhamento de progresso do Grupo de Estudos Musicais (GEM).
 
-A proposta do sistema é centralizar informações acadêmicas e administrativas do GEM, facilitando o cadastro de pessoas, comuns congregações, alunos e demais dados necessários para o acompanhamento das atividades musicais.
+A proposta do sistema é centralizar informações acadêmicas e administrativas do GEM, facilitando o cadastro de pessoas, comuns/congregações, alunos, instrutores, instrumentos, métodos e registros de aula.
 
 ## Visão geral
 
-O sistema está sendo desenvolvido em uma arquitetura com backend, frontend e banco de dados separados:
+O sistema é composto por:
 
-* **Backend:** API desenvolvida em Java com Spring Boot.
-* **Frontend:** aplicação desenvolvida em Flutter.
-* **Banco de dados:** PostgreSQL.
-* **Ambiente de execução:** Docker e Docker Compose.
+- **Backend:** API em Java com Spring Boot.
+- **Frontend:** aplicação em Flutter Web.
+- **Banco de dados:** PostgreSQL.
+- **Ambiente de execução:** Docker e Docker Compose.
 
-No estágio atual do desenvolvimento, o backend já possui estrutura para persistência de dados com JPA, conexão com PostgreSQL e seed automática em ambiente de desenvolvimento.
+Com Docker, o sistema completo pode ser executado com um único comando.
 
 ## Tecnologias utilizadas
 
-* Java
-* Spring Boot
-* Spring Data JPA
-* PostgreSQL
-* Docker
-* Docker Compose
-* Flutter
-* Dart
+- Java
+- Spring Boot
+- Spring Data JPA
+- PostgreSQL
+- Flutter
+- Dart
+- Docker
+- Docker Compose
+- Nginx
 
 ## Requisitos
 
-Para executar o projeto, é necessário ter instalado:
+Para executar o projeto completo, é necessário ter instalado:
 
-* Git
-* Docker
-* Docker Compose
-* Flutter SDK
-* Google Chrome, caso deseje executar o frontend no navegador
+- Git
+- Docker
+- Docker Compose
 
-> Observação: para executar o backend via Docker, não é necessário instalar Java ou Maven diretamente na máquina, pois o backend é construído dentro do container.
+> Não é necessário instalar Java, Maven, Flutter ou PostgreSQL diretamente na máquina para executar o projeto via Docker.
 
 ## Como clonar o projeto
 
@@ -53,7 +52,7 @@ git switch develop
 
 ## Configuração das variáveis de ambiente
 
-Antes de executar o projeto, crie um arquivo `.env` na raiz do repositório com base no arquivo `.env.example`:
+Antes de executar o projeto, crie um arquivo `.env` na raiz do repositório com base no `.env.example`:
 
 ```bash
 cp .env.example .env
@@ -69,9 +68,9 @@ DB_USER=gem_user
 DB_PASSWORD=123456
 ```
 
-Essas variáveis são utilizadas pelo Docker Compose para criar o banco PostgreSQL e configurar a conexão do backend com o banco de dados.
+Essas variáveis são utilizadas pelo Docker Compose para configurar o banco PostgreSQL e a conexão do backend.
 
-## Como executar o backend e o banco de dados
+## Como executar o projeto com Docker
 
 Na raiz do projeto, execute:
 
@@ -81,97 +80,106 @@ docker compose up --build
 
 Esse comando irá:
 
-* criar o container do PostgreSQL;
-* construir a imagem do backend;
-* executar a API Spring Boot;
-* conectar o backend ao banco de dados;
-* executar a seed automática de desenvolvimento, caso o banco ainda não possua dados.
+- criar e executar o container do PostgreSQL;
+- construir e executar o backend Spring Boot;
+- construir o frontend Flutter Web;
+- servir o frontend com Nginx;
+- conectar o backend ao banco de dados;
+- executar a seed automática de desenvolvimento, caso o banco ainda esteja vazio.
 
-A API ficará disponível em:
+Após a inicialização, acesse:
 
 ```text
-http://localhost:8080
+Frontend: http://localhost:3000
+Backend:  http://localhost:8080
 ```
+
+## Como parar o projeto
+
+Para parar os containers:
+
+```bash
+docker compose down
+```
+
+Para parar os containers e apagar também o volume do banco de dados:
+
+```bash
+docker compose down -v
+```
+
+> Atenção: `docker compose down -v` remove os dados locais do banco. Use apenas quando quiser recriar o banco do zero.
 
 ## Seed do banco de dados
 
-O projeto possui uma seed automática para facilitar os testes durante o desenvolvimento.
+O backend executa uma seed automática em ambiente de desenvolvimento.
 
-Essa seed é executada quando o backend sobe com o perfil de desenvolvimento ativo:
+A seed insere dados iniciais para testes, como:
 
-```env
-SPRING_PROFILES_ACTIVE=dev
-```
+- comuns;
+- pessoas;
+- alunos;
+- instrutores;
+- administrador;
+- instrumentos;
+- métodos;
+- registros de aula.
 
-No Docker Compose, esse perfil já é configurado no serviço do backend.
+Caso o banco já possua dados, a seed não insere registros novamente.
 
-A seed insere dados iniciais para testes, como comuns, pessoas e alunos. Caso o banco já possua dados, a seed não insere registros novamente, evitando duplicações.
-
-Para apagar os dados e testar a seed novamente do zero, execute:
+Para recriar o banco e executar a seed do zero:
 
 ```bash
 docker compose down -v
 docker compose up --build
 ```
 
-> Atenção: o comando `docker compose down -v` remove também o volume do banco de dados. Use apenas quando quiser limpar os dados locais de desenvolvimento.
-
 ## Endpoints básicos para teste
 
-Com o backend em execução, alguns endpoints disponíveis são:
+Com o projeto em execução, alguns endpoints disponíveis no backend são:
 
 ```text
 GET http://localhost:8080/comuns
 GET http://localhost:8080/pessoas
 GET http://localhost:8080/alunos
+GET http://localhost:8080/instrutores
+GET http://localhost:8080/instrumentos
+GET http://localhost:8080/metodos
+GET http://localhost:8080/registro-aulas
+GET http://localhost:8080/admins
 ```
 
-Esses endpoints podem ser testados pelo navegador, por ferramentas como Postman/Insomnia ou por terminal com `curl`.
-
-Exemplo:
+Exemplo com `curl`:
 
 ```bash
 curl http://localhost:8080/alunos
 ```
 
-## Como executar o frontend
-
-Em outro terminal, acesse a pasta do frontend:
-
-```bash
-cd frontend
-```
-
-Instale as dependências do Flutter:
-
-```bash
-flutter pub get
-```
-
-Execute a aplicação no Chrome:
-
-```bash
-flutter run -d chrome
-```
-
-O Flutter abrirá uma janela do navegador com a aplicação em execução.
-
 ## Estrutura do projeto
 
 ```text
 SistemaDeInstrutoresGEM/
-├── backend/              # API Java com Spring Boot
-├── frontend/             # Aplicação Flutter
-├── docker-compose.yml    # Serviços do PostgreSQL e backend
-├── .env.example          # Exemplo de variáveis de ambiente
-└── README.md             # Documentação principal do projeto
+├── backend/                # API Java com Spring Boot
+├── frontend/               # Aplicação Flutter Web
+├── docker-compose.yml      # Serviços do PostgreSQL, backend e frontend
+├── .env.example            # Exemplo de variáveis de ambiente
+└── README.md               # Documentação principal do projeto
+```
+
+## Documentação específica
+
+As instruções de execução manual e detalhes específicos de cada aplicação ficam nos READMEs internos:
+
+```text
+backend/README.md
+frontend/README.md
 ```
 
 ## Fluxo de desenvolvimento
 
 O desenvolvimento principal do projeto é realizado na branch `develop`.
 
-De forma geral, o fluxo recomendado é:
+Fluxo recomendado:
 
 ```bash
 git switch develop
@@ -191,8 +199,10 @@ Em seguida, abra um Pull Request para a branch `develop`.
 
 ## Observações importantes
 
-* O arquivo `.env` não deve ser versionado.
-* O arquivo `.env.example` deve ser mantido atualizado com as variáveis necessárias.
-* O banco de dados local é persistido em um volume Docker.
-* Para recriar o banco do zero, utilize `docker compose down -v`.
-* A branch `main` deve ser reservada para integrações finais ou entregas consolidadas do projeto.
+- O arquivo `.env` não deve ser versionado.
+- O arquivo `.env.example` deve ser mantido atualizado.
+- O banco de dados local é persistido em um volume Docker.
+- Para recriar o banco do zero, utilize `docker compose down -v`.
+- O frontend dockerizado é servido na porta `3000`.
+- O backend é servido na porta `8080`.
+- A branch `main` deve ser reservada para integrações finais ou entregas consolidadas do projeto.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,14 @@ services:
     ports:
       - "8080:8080"
 
+  frontend:
+    build:
+      context: ./frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"
+
 volumes:
   postgres_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+.dart_tool/
+build/
+.git/
+.gitignore
+README.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/cirruslabs/flutter:stable AS builder
+
+WORKDIR /app
+
+COPY pubspec.yaml pubspec.lock ./
+RUN flutter pub get
+
+COPY . .
+
+RUN flutter build web --release
+
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/build/web /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## O que foi feito

- Adiciona `Dockerfile` para buildar o frontend Flutter Web.
- Configura Nginx para servir os arquivos estáticos gerados pelo build do Flutter.
- Adiciona `.dockerignore` no frontend para evitar envio de arquivos desnecessários ao contexto Docker.
- Atualiza o `docker-compose.yml` para incluir o serviço `frontend`.
- Permite subir banco, backend e frontend com um único comando Docker.

Closes #68 