### PR TITLE
fix: corrigir fluxo de cadastro de pessoa e perfis

### DIFF
--- a/backend/src/main/java/com/gem/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/gem/backend/controller/AdminController.java
@@ -6,12 +6,14 @@ import com.gem.backend.service.AdminService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/admins")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
 
     private final AdminService service;

--- a/frontend/lib/models/admin.dart
+++ b/frontend/lib/models/admin.dart
@@ -1,0 +1,27 @@
+class Admin {
+  final int id;
+  final String nome;
+  final String? cpf;
+  final String? comum;
+
+  Admin({
+    required this.id,
+    required this.nome,
+    this.cpf,
+    this.comum,
+  });
+
+  factory Admin.fromJson(Map<String, dynamic> json) {
+    return Admin(
+      id: json['id'],
+      nome: json['nome']?.toString() ?? '',
+      cpf: json['cpf']?.toString(),
+      comum: json['comum']?.toString(),
+    );
+  }
+
+  String get comumCompleta {
+    final valor = comum?.trim() ?? '';
+    return valor.isEmpty ? 'Sem comum' : valor;
+  }
+}

--- a/frontend/lib/services/admin_service.dart
+++ b/frontend/lib/services/admin_service.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import '../config/api_config.dart';
+import '../models/admin.dart';
+
+class AdminService {
+  Future<List<Admin>> getAdmins() async {
+    final response = await ApiClient.get('/admins');
+
+    if (response.statusCode != 200) {
+      throw Exception('Erro ao buscar admins: ${response.statusCode}');
+    }
+
+    final List data = jsonDecode(response.body);
+    return data.map((e) => Admin.fromJson(e)).toList();
+  }
+
+  Future<Admin> getAdminById(int id) async {
+    final response = await ApiClient.get('/admins/$id');
+
+    if (response.statusCode != 200) {
+      throw Exception('Erro ao buscar admin: ${response.statusCode}');
+    }
+
+    final data = jsonDecode(response.body);
+    return Admin.fromJson(data);
+  }
+
+  Future<void> criarAdmin({
+    required String cpf,
+    required String senha,
+  }) async {
+    final adminBody = {
+      "senha": senha,
+      "pessoa": {"cpf": cpf},
+    };
+
+    final response = await ApiClient.post('/admins', jsonEncode(adminBody));
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw Exception(
+        'Erro ao cadastrar admin: ${response.statusCode} - ${response.body}',
+      );
+    }
+  }
+
+  Future<void> editarAdmin({
+    required int id,
+    required String cpf,
+    String? senha,
+  }) async {
+    final adminBody = {
+      "pessoa": {"cpf": cpf},
+      if (senha != null && senha.trim().isNotEmpty) "senha": senha.trim(),
+    };
+
+    final response = await ApiClient.put('/admins/$id', jsonEncode(adminBody));
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Erro ao editar admin: ${response.statusCode} - ${response.body}',
+      );
+    }
+  }
+
+  Future<void> deletarAdmin(int id) async {
+    final response = await ApiClient.delete('/admins/$id');
+
+    if (response.statusCode != 200 && response.statusCode != 204) {
+      throw Exception(
+        'Erro ao excluir admin: ${response.statusCode} - ${response.body}',
+      );
+    }
+  }
+}

--- a/frontend/lib/services/aluno_service.dart
+++ b/frontend/lib/services/aluno_service.dart
@@ -38,33 +38,10 @@ class AlunoService {
     return data.map((e) => Comum.fromJson(e)).toList();
   }
 
-  Future<void> criarAluno({
-    required String nome,
-    required String cpf,
-    required String senha,
-    required int comumId,
-  }) async {
-    final pessoaBody = {
-      "cpf": cpf,
-      "nome": nome,
-      "comum": {"id": comumId},
-    };
-
-    final pessoaResponse = await ApiClient.post(
-      '/pessoas',
-      jsonEncode(pessoaBody),
-    );
-
-    if (pessoaResponse.statusCode != 200 && pessoaResponse.statusCode != 201) {
-      throw Exception(
-        'Erro ao cadastrar pessoa: ${pessoaResponse.statusCode} - ${pessoaResponse.body}',
-      );
-    }
-
+  Future<void> criarAluno({required String cpf, required String senha}) async {
     final alunoBody = {
       "senha": senha,
       "pessoa": {"cpf": cpf},
-      "comum": {"id": comumId},
     };
 
     final alunoResponse = await ApiClient.post(
@@ -79,32 +56,9 @@ class AlunoService {
     }
   }
 
-  Future<void> editarAluno({
-    required int id,
-    required String nome,
-    required String cpf,
-    required int comumId,
-  }) async {
-    final pessoaBody = {
-      "cpf": cpf,
-      "nome": nome,
-      "comum": {"id": comumId},
-    };
-
-    final pessoaResponse = await ApiClient.put(
-      '/pessoas/$cpf',
-      jsonEncode(pessoaBody),
-    );
-
-    if (pessoaResponse.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar pessoa: ${pessoaResponse.statusCode} - ${pessoaResponse.body}',
-      );
-    }
-
+  Future<void> editarAluno({required int id, required String cpf}) async {
     final alunoBody = {
       "pessoa": {"cpf": cpf},
-      "comum": {"id": comumId},
     };
 
     final alunoResponse = await ApiClient.put(

--- a/frontend/lib/services/aluno_service.dart
+++ b/frontend/lib/services/aluno_service.dart
@@ -38,7 +38,10 @@ class AlunoService {
     return data.map((e) => Comum.fromJson(e)).toList();
   }
 
-  Future<void> criarAluno({required String cpf, required String senha}) async {
+  Future<void> criarAluno({
+    required String cpf,
+    required String senha,
+  }) async {
     final alunoBody = {
       "senha": senha,
       "pessoa": {"cpf": cpf},
@@ -56,9 +59,14 @@ class AlunoService {
     }
   }
 
-  Future<void> editarAluno({required int id, required String cpf}) async {
+  Future<void> editarAluno({
+    required int id,
+    required String cpf,
+    String? senha,
+  }) async {
     final alunoBody = {
       "pessoa": {"cpf": cpf},
+      if (senha != null && senha.trim().isNotEmpty) "senha": senha.trim(),
     };
 
     final alunoResponse = await ApiClient.put(

--- a/frontend/lib/services/instrutor_service.dart
+++ b/frontend/lib/services/instrutor_service.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import '../config/api_config.dart';
-import '../models/comum.dart';
 import '../models/instrutor.dart';
 
 class InstrutorService {
@@ -27,40 +26,10 @@ class InstrutorService {
     return Instrutor.fromJson(data);
   }
 
-  Future<List<Comum>> getComuns() async {
-    final response = await ApiClient.get('/comuns');
-
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar comuns: ${response.statusCode}');
-    }
-
-    final List data = jsonDecode(response.body);
-    return data.map((e) => Comum.fromJson(e)).toList();
-  }
-
   Future<void> criarInstrutor({
-    required String nome,
     required String cpf,
     required String senha,
-    required int comumId,
   }) async {
-    final pessoaBody = {
-      "cpf": cpf,
-      "nome": nome,
-      "comum": {"id": comumId},
-    };
-
-    final pessoaResponse = await ApiClient.post(
-      '/pessoas',
-      jsonEncode(pessoaBody),
-    );
-
-    if (pessoaResponse.statusCode != 200 && pessoaResponse.statusCode != 201) {
-      throw Exception(
-        'Erro ao cadastrar pessoa: ${pessoaResponse.statusCode} - ${pessoaResponse.body}',
-      );
-    }
-
     final instrutorBody = {
       "senha": senha,
       "pessoa": {"cpf": cpf},
@@ -81,27 +50,8 @@ class InstrutorService {
 
   Future<void> editarInstrutor({
     required int id,
-    required String nome,
     required String cpf,
-    required int comumId,
   }) async {
-    final pessoaBody = {
-      "cpf": cpf,
-      "nome": nome,
-      "comum": {"id": comumId},
-    };
-
-    final pessoaResponse = await ApiClient.put(
-      '/pessoas/$cpf',
-      jsonEncode(pessoaBody),
-    );
-
-    if (pessoaResponse.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar pessoa: ${pessoaResponse.statusCode} - ${pessoaResponse.body}',
-      );
-    }
-
     final instrutorBody = {
       "pessoa": {"cpf": cpf},
     };

--- a/frontend/lib/services/instrutor_service.dart
+++ b/frontend/lib/services/instrutor_service.dart
@@ -51,9 +51,11 @@ class InstrutorService {
   Future<void> editarInstrutor({
     required int id,
     required String cpf,
+    String? senha,
   }) async {
     final instrutorBody = {
       "pessoa": {"cpf": cpf},
+      if (senha != null && senha.trim().isNotEmpty) "senha": senha.trim(),
     };
 
     final instrutorResponse = await ApiClient.put(

--- a/frontend/lib/views/admin/admin_home_page.dart
+++ b/frontend/lib/views/admin/admin_home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../services/admin_service.dart';
 import '../../services/aluno_service.dart';
 import '../../services/comum_service.dart';
 import '../../services/instrumento_service.dart';
@@ -8,6 +9,8 @@ import '../../services/metodo_service.dart';
 import '../../services/pessoa_service.dart';
 import '../../services/registro_aula_service.dart';
 import '../../widgets/logout_button.dart';
+import '../admin_form/admin_form_page.dart';
+import '../admin_list/admin_list_page.dart';
 import '../aluno_form/aluno_form_page.dart';
 import '../aluno_list/aluno_list_page.dart';
 import '../comum_form/comum_form_page.dart';
@@ -31,6 +34,7 @@ class AdminHomePage extends StatefulWidget {
 }
 
 class _AdminHomePageState extends State<AdminHomePage> {
+  final AdminService adminService = AdminService();
   final AlunoService alunoService = AlunoService();
   final PessoaService pessoaService = PessoaService();
   final ComumService comumService = ComumService();
@@ -42,6 +46,7 @@ class _AdminHomePageState extends State<AdminHomePage> {
   bool loading = true;
   String? erro;
 
+  int totalAdmins = 0;
   int totalAlunos = 0;
   int totalPessoas = 0;
   int totalComuns = 0;
@@ -63,6 +68,7 @@ class _AdminHomePageState extends State<AdminHomePage> {
     });
 
     try {
+      final admins = await adminService.getAdmins();
       final alunos = await alunoService.getAlunos();
       final pessoas = await pessoaService.getPessoas();
       final comuns = await comumService.getComuns();
@@ -72,6 +78,7 @@ class _AdminHomePageState extends State<AdminHomePage> {
       final registrosAula = await registroAulaService.getRegistrosAula();
 
       setState(() {
+        totalAdmins = admins.length;
         totalAlunos = alunos.length;
         totalPessoas = pessoas.length;
         totalComuns = comuns.length;
@@ -172,6 +179,12 @@ class _AdminHomePageState extends State<AdminHomePage> {
                 _ResumoGrid(
                   children: [
                     _ResumoCard(
+                      titulo: 'Administradores',
+                      total: totalAdmins,
+                      icone: Icons.admin_panel_settings,
+                      onTap: () => abrirTela(const AdminListPage()),
+                    ),
+                    _ResumoCard(
                       titulo: 'Alunos',
                       total: totalAlunos,
                       icone: Icons.school,
@@ -223,6 +236,11 @@ class _AdminHomePageState extends State<AdminHomePage> {
                 const SizedBox(height: 12),
                 _AcoesGrid(
                   children: [
+                    _AcaoRapidaCard(
+                      texto: 'Novo administrador',
+                      icone: Icons.admin_panel_settings,
+                      onTap: () => abrirTela(const AdminFormPage()),
+                    ),
                     _AcaoRapidaCard(
                       texto: 'Novo aluno',
                       icone: Icons.person_add,

--- a/frontend/lib/views/admin_form/admin_form_page.dart
+++ b/frontend/lib/views/admin_form/admin_form_page.dart
@@ -1,23 +1,23 @@
 import 'package:flutter/material.dart';
 
-import '../../models/instrutor.dart';
+import '../../models/admin.dart';
 import '../../models/pessoa.dart';
-import '../../services/instrutor_service.dart';
+import '../../services/admin_service.dart';
 import '../../services/pessoa_service.dart';
 import '../../widgets/searchable_selection.dart';
 
-class InstrutorFormPage extends StatefulWidget {
-  final Instrutor? instrutor;
+class AdminFormPage extends StatefulWidget {
+  final Admin? admin;
 
-  const InstrutorFormPage({super.key, this.instrutor});
+  const AdminFormPage({super.key, this.admin});
 
   @override
-  State<InstrutorFormPage> createState() => _InstrutorFormPageState();
+  State<AdminFormPage> createState() => _AdminFormPageState();
 }
 
-class _InstrutorFormPageState extends State<InstrutorFormPage> {
+class _AdminFormPageState extends State<AdminFormPage> {
   final _formKey = GlobalKey<FormState>();
-  final InstrutorService service = InstrutorService();
+  final AdminService service = AdminService();
   final PessoaService pessoaService = PessoaService();
 
   final TextEditingController senhaController = TextEditingController();
@@ -29,14 +29,14 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
   bool salvando = false;
   String? erro;
 
-  bool get isEdicao => widget.instrutor != null;
+  bool get isEdicao => widget.admin != null;
 
   @override
   void initState() {
     super.initState();
 
-    if (widget.instrutor != null) {
-      cpfSelecionado = widget.instrutor!.cpf;
+    if (widget.admin != null) {
+      cpfSelecionado = widget.admin!.cpf;
     }
 
     carregarPessoas();
@@ -80,12 +80,13 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
 
     try {
       if (isEdicao) {
-        await service.editarInstrutor(
-          id: widget.instrutor!.id,
+        await service.editarAdmin(
+          id: widget.admin!.id,
           cpf: cpfSelecionado!,
+          senha: senhaController.text.trim(),
         );
       } else {
-        await service.criarInstrutor(
+        await service.criarAdmin(
           cpf: cpfSelecionado!,
           senha: senhaController.text.trim(),
         );
@@ -109,15 +110,13 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
   }
 
   String? validarSenha(String? value) {
-    if (isEdicao) return null;
-
     final senha = value?.trim() ?? '';
 
-    if (senha.isEmpty) {
+    if (!isEdicao && senha.isEmpty) {
       return 'Informe a senha';
     }
 
-    if (senha.length > 16) {
+    if (senha.isNotEmpty && senha.length > 16) {
       return 'Senha deve ter no máximo 16 caracteres';
     }
 
@@ -140,7 +139,9 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(isEdicao ? 'Editar Instrutor' : 'Cadastrar Instrutor'),
+        title: Text(
+          isEdicao ? 'Editar Administrador' : 'Cadastrar Administrador',
+        ),
       ),
       body: loading
           ? const Center(child: CircularProgressIndicator())
@@ -184,18 +185,16 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
                       },
                     ),
                     const SizedBox(height: 16),
-                    if (!isEdicao) ...[
-                      TextFormField(
-                        controller: senhaController,
-                        obscureText: true,
-                        decoration: const InputDecoration(
-                          labelText: 'Senha',
-                          border: OutlineInputBorder(),
-                        ),
-                        validator: validarSenha,
+                    TextFormField(
+                      controller: senhaController,
+                      obscureText: true,
+                      decoration: InputDecoration(
+                        labelText: isEdicao ? 'Nova senha (opcional)' : 'Senha',
+                        border: const OutlineInputBorder(),
                       ),
-                      const SizedBox(height: 16),
-                    ],
+                      validator: validarSenha,
+                    ),
+                    const SizedBox(height: 16),
                     ElevatedButton(
                       onPressed: salvando ? null : salvar,
                       child: Text(

--- a/frontend/lib/views/admin_list/admin_list_page.dart
+++ b/frontend/lib/views/admin_list/admin_list_page.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+
+import '../../models/admin.dart';
+import '../../services/admin_service.dart';
+import '../admin_form/admin_form_page.dart';
+
+class AdminListPage extends StatefulWidget {
+  const AdminListPage({super.key});
+
+  @override
+  State<AdminListPage> createState() => _AdminListPageState();
+}
+
+class _AdminListPageState extends State<AdminListPage> {
+  final AdminService service = AdminService();
+
+  List<Admin> admins = [];
+  List<Admin> adminsFiltrados = [];
+
+  bool loading = true;
+  String? erro;
+
+  @override
+  void initState() {
+    super.initState();
+    carregarAdmins();
+  }
+
+  Future<void> carregarAdmins() async {
+    setState(() {
+      loading = true;
+      erro = null;
+    });
+
+    try {
+      final lista = await service.getAdmins();
+
+      setState(() {
+        admins = lista;
+        adminsFiltrados = lista;
+        loading = false;
+      });
+    } catch (e) {
+      setState(() {
+        erro = e.toString();
+        loading = false;
+      });
+    }
+  }
+
+  void filtrarAdmins(String texto) {
+    final busca = texto.toLowerCase();
+
+    final resultado = admins.where((admin) {
+      return admin.nome.toLowerCase().contains(busca) ||
+          (admin.cpf ?? '').contains(busca) ||
+          (admin.comum ?? '').toLowerCase().contains(busca);
+    }).toList();
+
+    setState(() {
+      adminsFiltrados = resultado;
+    });
+  }
+
+  Future<void> adicionarAdmin() async {
+    final resultado = await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const AdminFormPage()),
+    );
+
+    if (resultado == true) {
+      carregarAdmins();
+    }
+  }
+
+  Future<void> editarAdmin(Admin admin) async {
+    try {
+      final adminCompleto = await service.getAdminById(admin.id);
+
+      if (!mounted) return;
+
+      final resultado = await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => AdminFormPage(admin: adminCompleto),
+        ),
+      );
+
+      if (resultado == true) {
+        carregarAdmins();
+      }
+    } catch (e) {
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Erro ao carregar admin: $e')));
+    }
+  }
+
+  Future<void> confirmarExclusao(Admin admin) async {
+    final confirmar = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('Excluir administrador'),
+          content: Text('Deseja excluir o administrador ${admin.nome}?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('Cancelar'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('Excluir'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmar == true) {
+      try {
+        await service.deletarAdmin(admin.id);
+        await carregarAdmins();
+
+        if (!mounted) return;
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Administrador excluído com sucesso.')),
+        );
+      } catch (e) {
+        if (!mounted) return;
+
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Erro ao excluir: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Administradores'),
+        actions: [
+          IconButton(
+            onPressed: carregarAdmins,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Atualizar',
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: adicionarAdmin,
+        child: const Icon(Icons.add),
+      ),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : erro != null
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Erro ao carregar administradores:\n$erro',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            )
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: TextField(
+                    decoration: const InputDecoration(
+                      hintText: 'Buscar administrador...',
+                      border: OutlineInputBorder(),
+                      prefixIcon: Icon(Icons.search),
+                    ),
+                    onChanged: filtrarAdmins,
+                  ),
+                ),
+                Expanded(
+                  child: admins.isEmpty
+                      ? const Center(
+                          child: Text(
+                            'Nenhum administrador cadastrado.',
+                            style: TextStyle(fontSize: 16),
+                          ),
+                        )
+                      : adminsFiltrados.isEmpty
+                      ? const Center(
+                          child: Text(
+                            'Nenhum administrador encontrado na busca.',
+                            style: TextStyle(fontSize: 16),
+                          ),
+                        )
+                      : ListView.separated(
+                          itemCount: adminsFiltrados.length,
+                          separatorBuilder: (context, index) =>
+                              const Divider(height: 1),
+                          itemBuilder: (context, index) {
+                            final admin = adminsFiltrados[index];
+
+                            return ListTile(
+                              leading: CircleAvatar(
+                                child: Text(
+                                  admin.nome.isNotEmpty
+                                      ? admin.nome[0].toUpperCase()
+                                      : '?',
+                                ),
+                              ),
+                              title: Text(admin.nome),
+                              subtitle: Text(
+                                [
+                                  admin.cpf ?? '',
+                                  admin.comumCompleta,
+                                ].where((item) => item.trim().isNotEmpty).join(' • '),
+                              ),
+                              onTap: () => editarAdmin(admin),
+                              trailing: IconButton(
+                                icon: const Icon(Icons.delete),
+                                onPressed: () => confirmarExclusao(admin),
+                              ),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/frontend/lib/views/admin_list/admin_list_page.dart
+++ b/frontend/lib/views/admin_list/admin_list_page.dart
@@ -216,7 +216,9 @@ class _AdminListPageState extends State<AdminListPage> {
                                 [
                                   admin.cpf ?? '',
                                   admin.comumCompleta,
-                                ].where((item) => item.trim().isNotEmpty).join(' • '),
+                                ].where((item) => item.trim().isNotEmpty).join(
+                                  ' • ',
+                                ),
                               ),
                               onTap: () => editarAdmin(admin),
                               trailing: IconButton(

--- a/frontend/lib/views/aluno_form/aluno_form_page.dart
+++ b/frontend/lib/views/aluno_form/aluno_form_page.dart
@@ -80,7 +80,11 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
 
     try {
       if (isEdicao) {
-        await service.editarAluno(id: widget.aluno!.id, cpf: cpfSelecionado!);
+        await service.editarAluno(
+          id: widget.aluno!.id,
+          cpf: cpfSelecionado!,
+          senha: senhaController.text.trim(),
+        );
       } else {
         await service.criarAluno(
           cpf: cpfSelecionado!,
@@ -106,15 +110,13 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
   }
 
   String? validarSenha(String? value) {
-    if (isEdicao) return null;
-
     final senha = value?.trim() ?? '';
 
-    if (senha.isEmpty) {
+    if (!isEdicao && senha.isEmpty) {
       return 'Informe a senha';
     }
 
-    if (senha.length > 16) {
+    if (senha.isNotEmpty && senha.length > 16) {
       return 'Senha deve ter no máximo 16 caracteres';
     }
 
@@ -146,7 +148,7 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: Text(
-                  'Erro ao carregar comuns:\n$erro',
+                  'Erro ao carregar pessoas:\n$erro',
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -180,18 +182,15 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
                       },
                     ),
                     const SizedBox(height: 16),
-                    if (!isEdicao) ...[
-                      TextFormField(
-                        controller: senhaController,
-                        obscureText: true,
-                        decoration: const InputDecoration(
-                          labelText: 'Senha',
-                          border: OutlineInputBorder(),
-                        ),
-                        validator: validarSenha,
+                    TextFormField(
+                      controller: senhaController,
+                      obscureText: true,
+                      decoration: InputDecoration(
+                        labelText: isEdicao ? 'Nova senha (opcional)' : 'Senha',
+                        border: const OutlineInputBorder(),
                       ),
-                      const SizedBox(height: 16),
-                    ],
+                      validator: validarSenha,
+                    ),
                     const SizedBox(height: 24),
                     ElevatedButton(
                       onPressed: salvando ? null : salvar,

--- a/frontend/lib/views/aluno_form/aluno_form_page.dart
+++ b/frontend/lib/views/aluno_form/aluno_form_page.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
 import '../../models/aluno.dart';
-import '../../models/comum.dart';
+import '../../models/pessoa.dart';
 import '../../services/aluno_service.dart';
+import '../../services/pessoa_service.dart';
 import '../../widgets/searchable_selection.dart';
 
 class AlunoFormPage extends StatefulWidget {
@@ -17,13 +18,12 @@ class AlunoFormPage extends StatefulWidget {
 class _AlunoFormPageState extends State<AlunoFormPage> {
   final _formKey = GlobalKey<FormState>();
   final AlunoService service = AlunoService();
+  final PessoaService pessoaService = PessoaService();
 
-  final TextEditingController nomeController = TextEditingController();
-  final TextEditingController cpfController = TextEditingController();
   final TextEditingController senhaController = TextEditingController();
 
-  List<Comum> comuns = [];
-  int? comumSelecionadaId;
+  List<Pessoa> pessoas = [];
+  String? cpfSelecionado;
 
   bool loading = true;
   bool salvando = false;
@@ -36,28 +36,24 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
     super.initState();
 
     if (widget.aluno != null) {
-      nomeController.text = widget.aluno!.nome;
-      cpfController.text = widget.aluno!.cpf ?? '';
-      comumSelecionadaId = widget.aluno!.comumId;
+      cpfSelecionado = widget.aluno!.cpf;
     }
 
-    carregarComuns();
+    carregarPessoas();
   }
 
   @override
   void dispose() {
-    nomeController.dispose();
-    cpfController.dispose();
     senhaController.dispose();
     super.dispose();
   }
 
-  Future<void> carregarComuns() async {
+  Future<void> carregarPessoas() async {
     try {
-      final lista = await service.getComuns();
+      final lista = await pessoaService.getPessoas();
 
       setState(() {
-        comuns = lista;
+        pessoas = lista;
         loading = false;
       });
     } catch (e) {
@@ -71,10 +67,10 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
   Future<void> salvar() async {
     if (!_formKey.currentState!.validate()) return;
 
-    if (comumSelecionadaId == null) {
+    if (cpfSelecionado == null) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('Selecione uma comum')));
+      ).showSnackBar(const SnackBar(content: Text('Selecione uma pessoa')));
       return;
     }
 
@@ -84,18 +80,11 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
 
     try {
       if (isEdicao) {
-        await service.editarAluno(
-          id: widget.aluno!.id,
-          nome: nomeController.text.trim(),
-          cpf: cpfController.text.trim(),
-          comumId: comumSelecionadaId!,
-        );
+        await service.editarAluno(id: widget.aluno!.id, cpf: cpfSelecionado!);
       } else {
         await service.criarAluno(
-          nome: nomeController.text.trim(),
-          cpf: cpfController.text.trim(),
+          cpf: cpfSelecionado!,
           senha: senhaController.text.trim(),
-          comumId: comumSelecionadaId!,
         );
       }
 
@@ -116,24 +105,6 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
     }
   }
 
-  String? validarCpf(String? value) {
-    final cpf = value?.trim() ?? '';
-
-    if (cpf.isEmpty) {
-      return 'Informe o CPF';
-    }
-
-    if (cpf.length != 11) {
-      return 'CPF deve ter 11 dígitos';
-    }
-
-    if (!RegExp(r'^[0-9]+$').hasMatch(cpf)) {
-      return 'CPF deve conter apenas números';
-    }
-
-    return null;
-  }
-
   String? validarSenha(String? value) {
     if (isEdicao) return null;
 
@@ -150,19 +121,13 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
     return null;
   }
 
-  String textoComum(Comum comum) {
-    final partes = <String>[
-      comum.nome,
-      comum.cidade ?? '',
-      comum.estado ?? '',
-    ].where((item) => item.trim().isNotEmpty).toList();
-
-    return partes.join(' - ');
+  String textoPessoa(Pessoa pessoa) {
+    return '${pessoa.nome} - ${pessoa.cpf}';
   }
 
-  Comum? comumSelecionada() {
-    for (final comum in comuns) {
-      if (comum.id == comumSelecionadaId) return comum;
+  Pessoa? pessoaSelecionada() {
+    for (final pessoa in pessoas) {
+      if (pessoa.cpf == cpfSelecionado) return pessoa;
     }
 
     return null;
@@ -192,36 +157,27 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
                 key: _formKey,
                 child: ListView(
                   children: [
-                    TextFormField(
-                      controller: nomeController,
-                      decoration: const InputDecoration(
-                        labelText: 'Nome',
-                        border: OutlineInputBorder(),
-                      ),
-                      textCapitalization: TextCapitalization.words,
+                    SearchableSelectionField<Pessoa>(
+                      labelText: 'Pessoa',
+                      dialogTitle: 'Selecionar pessoa',
+                      items: pessoas,
+                      value: pessoaSelecionada(),
+                      itemTitle: textoPessoa,
+                      itemSubtitle: (pessoa) => pessoa.comumCompleta,
+                      itemSearchText: (pessoa) =>
+                          '${pessoa.nome} ${pessoa.cpf} ${pessoa.comumCompleta}',
+                      searchHintText: 'Buscar por nome, CPF ou comum...',
+                      onChanged: (pessoa) {
+                        setState(() {
+                          cpfSelecionado = pessoa?.cpf;
+                        });
+                      },
                       validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'Informe o nome';
+                        if (value == null) {
+                          return 'Selecione uma pessoa';
                         }
-
-                        if (value.trim().length > 64) {
-                          return 'Nome deve ter no máximo 64 caracteres';
-                        }
-
                         return null;
                       },
-                    ),
-                    const SizedBox(height: 16),
-                    TextFormField(
-                      controller: cpfController,
-                      enabled: !isEdicao,
-                      decoration: const InputDecoration(
-                        labelText: 'CPF',
-                        border: OutlineInputBorder(),
-                        helperText: 'Digite apenas números',
-                      ),
-                      keyboardType: TextInputType.number,
-                      validator: validarCpf,
                     ),
                     const SizedBox(height: 16),
                     if (!isEdicao) ...[
@@ -236,28 +192,6 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
                       ),
                       const SizedBox(height: 16),
                     ],
-                    SearchableSelectionField<Comum>(
-                      labelText: 'Comum',
-                      dialogTitle: 'Selecionar comum',
-                      items: comuns,
-                      value: comumSelecionada(),
-                      itemTitle: textoComum,
-                      itemSubtitle: (comum) => comum.bairro,
-                      itemSearchText: (comum) =>
-                          '${comum.nome} ${comum.cidade ?? ''} ${comum.estado ?? ''}',
-                      searchHintText: 'Buscar por nome, cidade ou estado...',
-                      onChanged: (comum) {
-                        setState(() {
-                          comumSelecionadaId = comum?.id;
-                        });
-                      },
-                      validator: (value) {
-                        if (value == null) {
-                          return 'Selecione uma comum';
-                        }
-                        return null;
-                      },
-                    ),
                     const SizedBox(height: 24),
                     ElevatedButton(
                       onPressed: salvando ? null : salvar,

--- a/frontend/lib/views/instrutor_form/instrutor_form_page.dart
+++ b/frontend/lib/views/instrutor_form/instrutor_form_page.dart
@@ -83,6 +83,7 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
         await service.editarInstrutor(
           id: widget.instrutor!.id,
           cpf: cpfSelecionado!,
+          senha: senhaController.text.trim(),
         );
       } else {
         await service.criarInstrutor(
@@ -109,15 +110,13 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
   }
 
   String? validarSenha(String? value) {
-    if (isEdicao) return null;
-
     final senha = value?.trim() ?? '';
 
-    if (senha.isEmpty) {
+    if (!isEdicao && senha.isEmpty) {
       return 'Informe a senha';
     }
 
-    if (senha.length > 16) {
+    if (senha.isNotEmpty && senha.length > 16) {
       return 'Senha deve ter no máximo 16 caracteres';
     }
 
@@ -184,18 +183,16 @@ class _InstrutorFormPageState extends State<InstrutorFormPage> {
                       },
                     ),
                     const SizedBox(height: 16),
-                    if (!isEdicao) ...[
-                      TextFormField(
-                        controller: senhaController,
-                        obscureText: true,
-                        decoration: const InputDecoration(
-                          labelText: 'Senha',
-                          border: OutlineInputBorder(),
-                        ),
-                        validator: validarSenha,
+                    TextFormField(
+                      controller: senhaController,
+                      obscureText: true,
+                      decoration: InputDecoration(
+                        labelText: isEdicao ? 'Nova senha (opcional)' : 'Senha',
+                        border: const OutlineInputBorder(),
                       ),
-                      const SizedBox(height: 16),
-                    ],
+                      validator: validarSenha,
+                    ),
+                    const SizedBox(height: 16),
                     ElevatedButton(
                       onPressed: salvando ? null : salvar,
                       child: Text(


### PR DESCRIPTION
## Descrição

Esta PR corrige o fluxo de cadastro de usuários no sistema, separando o cadastro de `Pessoa` da atribuição de perfis como `Aluno`, `Instrutor` e `Admin`.

Antes, ao cadastrar aluno ou instrutor, o frontend criava uma nova pessoa automaticamente dentro do próprio fluxo de cadastro do perfil. Isso misturava responsabilidades e poderia gerar inconsistências, já que `Pessoa` é a entidade base do sistema e os perfis devem apenas referenciar uma pessoa já cadastrada.

Com esta alteração, o fluxo passa a ser:

1. Cadastrar uma `Pessoa`;
2. Selecionar essa `Pessoa` ao cadastrar um `Aluno`, `Instrutor` ou `Admin`;
3. Criar apenas o vínculo do perfil com a pessoa selecionada.

## Alterações realizadas

* Ajustado o cadastro de alunos para selecionar uma pessoa existente;
* Ajustado o cadastro de instrutores para selecionar uma pessoa existente;
* Adicionado CRUD de administradores na área administrativa;
* Integrado o gerenciamento de administradores à tela do administrador;
* Permitida a redefinição de senha de alunos, instrutores e administradores pelo administrador;
* Mantido o comportamento de não exibir senha atual em telas de edição;
* Ajustado o envio de senha opcional na edição: se o campo ficar vazio, a senha atual é preservada;
* Protegido o CRUD de administradores para acesso apenas por usuários com perfil `ADMIN`.

## Como testar

1. Fazer login com um usuário administrador;
2. Cadastrar uma nova pessoa;
3. Cadastrar um aluno selecionando essa pessoa;
4. Cadastrar um instrutor selecionando uma pessoa existente;
5. Cadastrar um administrador selecionando uma pessoa existente;
6. Editar aluno, instrutor e administrador redefinindo senha;
7. Editar aluno, instrutor e administrador deixando a senha em branco e verificar que a senha anterior é preservada;
8. Fazer logout e testar login com os usuários criados ou com senha redefinida.

## Observações

Esta PR melhora a consistência do modelo do sistema, deixando `Pessoa` como entidade base e evitando que cadastros de perfis criem pessoas implicitamente.

Closes #130
