### PR TITLE
#131 correção do retorno de erros na interface

### DIFF
--- a/frontend/lib/config/api_config.dart
+++ b/frontend/lib/config/api_config.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 
@@ -69,13 +71,101 @@ class AuthSession {
   }
 }
 
+class ApiException implements Exception {
+  final int? statusCode;
+  final String message;
+  final List<String> details;
+
+  const ApiException(this.message, {this.statusCode, this.details = const []});
+
+  factory ApiException.fromResponse(
+    http.Response response, {
+    String? fallbackMessage,
+  }) {
+    final body = response.body.trim();
+
+    if (body.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(body);
+
+        if (decoded is Map<String, dynamic>) {
+          final message = decoded['message']?.toString().trim();
+          final error = decoded['error']?.toString().trim();
+          final parsedDetails = _parseDetails(decoded['details']);
+
+          if (message != null && message.isNotEmpty) {
+            return ApiException(
+              message,
+              statusCode: response.statusCode,
+              details: parsedDetails,
+            );
+          }
+
+          if (error != null && error.isNotEmpty) {
+            return ApiException(
+              error,
+              statusCode: response.statusCode,
+              details: parsedDetails,
+            );
+          }
+        }
+
+        if (decoded is String && decoded.trim().isNotEmpty) {
+          return ApiException(decoded.trim(), statusCode: response.statusCode);
+        }
+      } catch (_) {
+        // Se o corpo da resposta não for JSON válido, usa fallback abaixo.
+      }
+    }
+
+    return ApiException(
+      fallbackMessage ?? _defaultMessageForStatus(response.statusCode),
+      statusCode: response.statusCode,
+    );
+  }
+
+  static List<String> _parseDetails(dynamic details) {
+    if (details is! List) return [];
+
+    return details
+        .where((item) => item != null)
+        .map((item) => item.toString().trim())
+        .where((item) => item.isNotEmpty)
+        .toList();
+  }
+
+  static String _defaultMessageForStatus(int statusCode) {
+    switch (statusCode) {
+      case 400:
+        return 'Dados inválidos. Verifique as informações enviadas.';
+      case 401:
+        return 'Sessão inválida ou expirada. Faça login novamente.';
+      case 403:
+        return 'Você não tem permissão para realizar esta ação.';
+      case 404:
+        return 'Registro não encontrado.';
+      case 409:
+        return 'Não foi possível concluir a operação por conflito nos dados.';
+      case 500:
+        return 'Erro interno no servidor.';
+      default:
+        return 'Erro inesperado na comunicação com o servidor.';
+    }
+  }
+
+  @override
+  String toString() {
+    if (details.isEmpty) return message;
+
+    return '$message\n${details.map((detail) => '• $detail').join('\n')}';
+  }
+}
+
 class ApiClient {
   static Uri uri(String path) => Uri.parse('${ApiConfig.baseUrl}$path');
 
   static Map<String, String> headers({bool json = false}) {
-    final headers = <String, String>{
-      'Accept': 'application/json',
-    };
+    final headers = <String, String>{'Accept': 'application/json'};
 
     if (json) {
       headers['Content-Type'] = 'application/json';
@@ -90,18 +180,47 @@ class ApiClient {
   }
 
   static Future<http.Response> get(String path) {
-    return http.get(uri(path), headers: headers());
+    return _send(() => http.get(uri(path), headers: headers()));
   }
 
   static Future<http.Response> post(String path, Object? body) {
-    return http.post(uri(path), headers: headers(json: true), body: body);
+    return _send(
+      () => http.post(uri(path), headers: headers(json: true), body: body),
+    );
   }
 
   static Future<http.Response> put(String path, Object? body) {
-    return http.put(uri(path), headers: headers(json: true), body: body);
+    return _send(
+      () => http.put(uri(path), headers: headers(json: true), body: body),
+    );
   }
 
   static Future<http.Response> delete(String path) {
-    return http.delete(uri(path), headers: headers());
+    return _send(() => http.delete(uri(path), headers: headers()));
+  }
+
+  static Future<http.Response> _send(
+    Future<http.Response> Function() request,
+  ) async {
+    try {
+      return await request();
+    } catch (_) {
+      throw const ApiException(
+        'Não foi possível conectar ao servidor. Tente novamente mais tarde',
+      );
+    }
+  }
+
+  static void ensureSuccess(
+    http.Response response, {
+    List<int> acceptedStatusCodes = const [200],
+    String? fallbackMessage,
+  }) {
+    if (!acceptedStatusCodes.contains(response.statusCode)) {
+      throw ApiException.fromResponse(
+        response,
+        fallbackMessage: fallbackMessage,
+      );
+    }
   }
 }

--- a/frontend/lib/services/admin_service.dart
+++ b/frontend/lib/services/admin_service.dart
@@ -7,9 +7,10 @@ class AdminService {
   Future<List<Admin>> getAdmins() async {
     final response = await ApiClient.get('/admins');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar admins: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar administradores.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Admin.fromJson(e)).toList();
@@ -18,9 +19,10 @@ class AdminService {
   Future<Admin> getAdminById(int id) async {
     final response = await ApiClient.get('/admins/$id');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar admin: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar administrador.',
+    );
 
     final data = jsonDecode(response.body);
     return Admin.fromJson(data);
@@ -37,11 +39,11 @@ class AdminService {
 
     final response = await ApiClient.post('/admins', jsonEncode(adminBody));
 
-    if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception(
-        'Erro ao cadastrar admin: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao cadastrar administrador.',
+    );
   }
 
   Future<void> editarAdmin({
@@ -56,20 +58,19 @@ class AdminService {
 
     final response = await ApiClient.put('/admins/$id', jsonEncode(adminBody));
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar admin: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao editar administrador.',
+    );
   }
 
   Future<void> deletarAdmin(int id) async {
     final response = await ApiClient.delete('/admins/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir admin: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir administrador.',
+    );
   }
 }

--- a/frontend/lib/services/aluno_service.dart
+++ b/frontend/lib/services/aluno_service.dart
@@ -8,9 +8,10 @@ class AlunoService {
   Future<List<Aluno>> getAlunos() async {
     final response = await ApiClient.get('/alunos');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar alunos: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar alunos.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Aluno.fromJson(e)).toList();
@@ -19,9 +20,10 @@ class AlunoService {
   Future<Aluno> getMeuPerfil() async {
     final response = await ApiClient.get('/alunos/me');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar meu perfil: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar meu perfil.',
+    );
 
     final data = jsonDecode(response.body);
     return Aluno.fromJson(data);
@@ -30,9 +32,10 @@ class AlunoService {
   Future<List<Comum>> getComuns() async {
     final response = await ApiClient.get('/comuns');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar comuns: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar comuns.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Comum.fromJson(e)).toList();
@@ -52,11 +55,11 @@ class AlunoService {
       jsonEncode(alunoBody),
     );
 
-    if (alunoResponse.statusCode != 200 && alunoResponse.statusCode != 201) {
-      throw Exception(
-        'Erro ao cadastrar aluno: ${alunoResponse.statusCode} - ${alunoResponse.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      alunoResponse,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao cadastrar aluno.',
+    );
   }
 
   Future<void> editarAluno({
@@ -74,29 +77,29 @@ class AlunoService {
       jsonEncode(alunoBody),
     );
 
-    if (alunoResponse.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar aluno: ${alunoResponse.statusCode} - ${alunoResponse.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      alunoResponse,
+      fallbackMessage: 'Erro ao editar aluno.',
+    );
   }
 
   Future<void> deletarAluno(int id) async {
     final response = await ApiClient.delete('/alunos/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir aluno: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir aluno.',
+    );
   }
 
   Future<Aluno> getAlunoById(int id) async {
     final response = await ApiClient.get('/alunos/$id');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar aluno: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar aluno.',
+    );
 
     final data = jsonDecode(response.body);
     return Aluno.fromJson(data);

--- a/frontend/lib/services/auth_service.dart
+++ b/frontend/lib/services/auth_service.dart
@@ -13,9 +13,10 @@ class AuthService {
       jsonEncode({'cpf': cpf, 'senha': senha, 'perfil': perfil}),
     );
 
-    if (response.statusCode != 200) {
-      throw Exception('CPF, senha ou perfil inválido.');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'CPF, senha ou perfil inválido.',
+    );
 
     await AuthSession.salvar(jsonDecode(response.body));
   }

--- a/frontend/lib/services/comum_service.dart
+++ b/frontend/lib/services/comum_service.dart
@@ -7,9 +7,10 @@ class ComumService {
   Future<List<Comum>> getComuns() async {
     final response = await ApiClient.get('/comuns');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar comuns: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar comuns.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Comum.fromJson(e)).toList();
@@ -18,9 +19,10 @@ class ComumService {
   Future<Comum> getComumById(int id) async {
     final response = await ApiClient.get('/comuns/$id');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar comum: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar comum.',
+    );
 
     final data = jsonDecode(response.body);
     return Comum.fromJson(data);
@@ -41,11 +43,11 @@ class ComumService {
 
     final response = await ApiClient.post('/comuns', jsonEncode(body));
 
-    if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception(
-        'Erro ao criar comum: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao criar comum.',
+    );
   }
 
   Future<void> editarComum({
@@ -65,20 +67,19 @@ class ComumService {
 
     final response = await ApiClient.put('/comuns/$id', jsonEncode(body));
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar comum: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao editar comum.',
+    );
   }
 
   Future<void> deletarComum(int id) async {
     final response = await ApiClient.delete('/comuns/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir comum: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir comum.',
+    );
   }
 }

--- a/frontend/lib/services/instrumento_service.dart
+++ b/frontend/lib/services/instrumento_service.dart
@@ -7,11 +7,10 @@ class InstrumentoService {
   Future<List<Instrumento>> getInstrumentos() async {
     final response = await ApiClient.get('/instrumentos');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar instrumentos: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar instrumentos.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Instrumento.fromJson(e)).toList();
@@ -23,11 +22,11 @@ class InstrumentoService {
       jsonEncode({'nome': nome}),
     );
 
-    if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception(
-        'Erro ao criar instrumento: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao criar instrumento.',
+    );
   }
 
   Future<void> editarInstrumento({
@@ -39,20 +38,19 @@ class InstrumentoService {
       jsonEncode({'id': id, 'nome': nome}),
     );
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar instrumento: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao editar instrumento.',
+    );
   }
 
   Future<void> deletarInstrumento(int id) async {
     final response = await ApiClient.delete('/instrumentos/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir instrumento: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir instrumento.',
+    );
   }
 }

--- a/frontend/lib/services/instrutor_service.dart
+++ b/frontend/lib/services/instrutor_service.dart
@@ -7,9 +7,10 @@ class InstrutorService {
   Future<List<Instrutor>> getInstrutores() async {
     final response = await ApiClient.get('/instrutores');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar instrutores: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar instrutores.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Instrutor.fromJson(e)).toList();
@@ -18,9 +19,10 @@ class InstrutorService {
   Future<Instrutor> getInstrutorById(int id) async {
     final response = await ApiClient.get('/instrutores/$id');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar instrutor: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar instrutor.',
+    );
 
     final data = jsonDecode(response.body);
     return Instrutor.fromJson(data);
@@ -40,12 +42,11 @@ class InstrutorService {
       jsonEncode(instrutorBody),
     );
 
-    if (instrutorResponse.statusCode != 200 &&
-        instrutorResponse.statusCode != 201) {
-      throw Exception(
-        'Erro ao cadastrar instrutor: ${instrutorResponse.statusCode} - ${instrutorResponse.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      instrutorResponse,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao cadastrar instrutor.',
+    );
   }
 
   Future<void> editarInstrutor({
@@ -63,20 +64,19 @@ class InstrutorService {
       jsonEncode(instrutorBody),
     );
 
-    if (instrutorResponse.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar instrutor: ${instrutorResponse.statusCode} - ${instrutorResponse.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      instrutorResponse,
+      fallbackMessage: 'Erro ao editar instrutor.',
+    );
   }
 
   Future<void> deletarInstrutor(int id) async {
     final response = await ApiClient.delete('/instrutores/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir instrutor: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir instrutor.',
+    );
   }
 }

--- a/frontend/lib/services/metodo_service.dart
+++ b/frontend/lib/services/metodo_service.dart
@@ -8,11 +8,10 @@ class MetodoService {
   Future<List<Metodo>> getMetodos() async {
     final response = await ApiClient.get('/metodos');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar métodos: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar métodos.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Metodo.fromJson(e)).toList();
@@ -21,11 +20,10 @@ class MetodoService {
   Future<List<Instrumento>> getInstrumentos() async {
     final response = await ApiClient.get('/instrumentos');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar instrumentos: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar instrumentos.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Instrumento.fromJson(e)).toList();
@@ -43,11 +41,11 @@ class MetodoService {
       }),
     );
 
-    if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception(
-        'Erro ao criar método: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao criar método.',
+    );
   }
 
   Future<void> editarMetodo({
@@ -64,20 +62,19 @@ class MetodoService {
       }),
     );
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar método: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao editar método.',
+    );
   }
 
   Future<void> deletarMetodo(int id) async {
     final response = await ApiClient.delete('/metodos/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir método: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir método.',
+    );
   }
 }

--- a/frontend/lib/services/pessoa_service.dart
+++ b/frontend/lib/services/pessoa_service.dart
@@ -7,9 +7,10 @@ class PessoaService {
   Future<List<Pessoa>> getPessoas() async {
     final response = await ApiClient.get('/pessoas');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar pessoas: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar pessoas.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Pessoa.fromJson(e)).toList();
@@ -18,9 +19,10 @@ class PessoaService {
   Future<Pessoa> getPessoaByCpf(String cpf) async {
     final response = await ApiClient.get('/pessoas/$cpf');
 
-    if (response.statusCode != 200) {
-      throw Exception('Erro ao buscar pessoa: ${response.statusCode}');
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar pessoa.',
+    );
 
     final data = jsonDecode(response.body);
     return Pessoa.fromJson(data);
@@ -39,11 +41,11 @@ class PessoaService {
 
     final response = await ApiClient.post('/pessoas', jsonEncode(body));
 
-    if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception(
-        'Erro ao criar pessoa: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao criar pessoa.',
+    );
   }
 
   Future<void> editarPessoa({
@@ -59,20 +61,19 @@ class PessoaService {
 
     final response = await ApiClient.put('/pessoas/$cpf', jsonEncode(body));
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar pessoa: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao editar pessoa.',
+    );
   }
 
   Future<void> deletarPessoa(String cpf) async {
     final response = await ApiClient.delete('/pessoas/$cpf');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir pessoa: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir pessoa.',
+    );
   }
 }

--- a/frontend/lib/services/registro_aula_service.dart
+++ b/frontend/lib/services/registro_aula_service.dart
@@ -9,11 +9,10 @@ class RegistroAulaService {
   Future<List<RegistroAula>> getRegistrosAula() async {
     final response = await ApiClient.get('/registro-aulas');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar registros de aula: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar registros de aula.',
+    );
 
     final List data = jsonDecode(response.body);
     return _ordenarPorDataDesc(
@@ -24,11 +23,10 @@ class RegistroAulaService {
   Future<List<RegistroAula>> getMeuHistorico() async {
     final response = await ApiClient.get('/registro-aulas/meu-historico');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar meu histórico: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar meu histórico.',
+    );
 
     final List data = jsonDecode(response.body);
     return _ordenarPorDataDesc(
@@ -39,11 +37,10 @@ class RegistroAulaService {
   Future<List<Aluno>> getAlunos() async {
     final response = await ApiClient.get('/alunos');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar alunos: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar alunos.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Aluno.fromJson(e)).toList();
@@ -52,11 +49,10 @@ class RegistroAulaService {
   Future<List<Instrutor>> getInstrutores() async {
     final response = await ApiClient.get('/instrutores');
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao buscar instrutores: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao buscar instrutores.',
+    );
 
     final List data = jsonDecode(response.body);
     return data.map((e) => Instrutor.fromJson(e)).toList();
@@ -84,11 +80,11 @@ class RegistroAulaService {
       ),
     );
 
-    if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception(
-        'Erro ao criar registro de aula: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 201],
+      fallbackMessage: 'Erro ao criar registro de aula.',
+    );
   }
 
   Future<void> editarRegistroAula({
@@ -115,21 +111,20 @@ class RegistroAulaService {
       }),
     );
 
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Erro ao editar registro de aula: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      fallbackMessage: 'Erro ao editar registro de aula.',
+    );
   }
 
   Future<void> deletarRegistroAula(int id) async {
     final response = await ApiClient.delete('/registro-aulas/$id');
 
-    if (response.statusCode != 200 && response.statusCode != 204) {
-      throw Exception(
-        'Erro ao excluir registro de aula: ${response.statusCode} - ${response.body}',
-      );
-    }
+    ApiClient.ensureSuccess(
+      response,
+      acceptedStatusCodes: [200, 204],
+      fallbackMessage: 'Erro ao excluir registro de aula.',
+    );
   }
 
   Map<String, dynamic> _body({


### PR DESCRIPTION
## Descrição

Esta PR resolve a issue #131, melhorando a forma como o frontend trata e exibe os retornos de erro vindos da API.

Antes, alguns services exibiam o corpo bruto da resposta HTTP, fazendo com que mensagens de erro aparecessem de forma pouco amigável para o usuário. Agora, o tratamento foi centralizado no `ApiClient`, com uma nova `ApiException`, responsável por interpretar a resposta do backend e exibir mensagens mais claras.

## Alterações realizadas

* Adicionada a classe `ApiException` para padronizar erros da API no frontend.
* Centralizado o tratamento de erro HTTP no `ApiClient.ensureSuccess`.
* Adicionado tratamento para falha de conexão com o servidor.
* Atualizados os services para substituir `throw Exception(...)` com corpo bruto da resposta por mensagens tratadas.
* Mantida a leitura dos campos `message` e `details` enviados pelo backend.
* Melhorada a exibição de erros de validação, permitindo mostrar detalhes retornados pela API.

## Arquivos alterados

* `frontend/lib/config/api_config.dart`
* `frontend/lib/services/admin_service.dart`
* `frontend/lib/services/aluno_service.dart`
* `frontend/lib/services/auth_service.dart`
* `frontend/lib/services/comum_service.dart`
* `frontend/lib/services/instrumento_service.dart`
* `frontend/lib/services/instrutor_service.dart`
* `frontend/lib/services/metodo_service.dart`
* `frontend/lib/services/pessoa_service.dart`
* `frontend/lib/services/registro_aula_service.dart`

## Testes realizados

* Testado erro de conexão com o backend desligado.
* Testado retorno de erro em operações de cadastro/edição.
* Verificado que mensagens de erro não exibem mais o JSON bruto da resposta.
* Executado `flutter analyze`.

## Observação

A alteração não modifica o comportamento das requisições nem as regras de negócio. Apenas melhora a leitura e apresentação dos erros no frontend.

Closes #131 