### PR TITLE
feat: exibe instrumentos e métodos no perfil do aluno

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -49,6 +49,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa-test</artifactId>
             <scope>test</scope>

--- a/backend/src/main/java/com/gem/backend/config/DataSeeder.java
+++ b/backend/src/main/java/com/gem/backend/config/DataSeeder.java
@@ -2,6 +2,8 @@ package com.gem.backend.config;
 
 import com.gem.backend.model.Admin;
 import com.gem.backend.model.Aluno;
+import com.gem.backend.model.AlunoInstrumento;
+import com.gem.backend.model.AlunoMetodo;
 import com.gem.backend.model.Comum;
 import com.gem.backend.model.Instrumento;
 import com.gem.backend.model.Instrutor;
@@ -9,6 +11,8 @@ import com.gem.backend.model.Metodo;
 import com.gem.backend.model.Pessoa;
 import com.gem.backend.model.RegistroAula;
 import com.gem.backend.repository.AdminRepository;
+import com.gem.backend.repository.AlunoInstrumentoRepository;
+import com.gem.backend.repository.AlunoMetodoRepository;
 import com.gem.backend.repository.AlunoRepository;
 import com.gem.backend.repository.ComumRepository;
 import com.gem.backend.repository.InstrumentoRepository;
@@ -19,168 +23,139 @@ import com.gem.backend.repository.RegistroAulaRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
 
-@Configuration
+@Component
 @Profile("dev")
-public class DataSeeder {
+public class DataSeeder implements CommandLineRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(DataSeeder.class);
+    private static final String SENHA_USUARIO = "senha123";
+    private static final String SENHA_ADMIN = "admin123";
 
-    @Bean
-    CommandLineRunner seedDatabase(
+    private final ComumRepository comumRepository;
+    private final PessoaRepository pessoaRepository;
+    private final AlunoRepository alunoRepository;
+    private final AlunoInstrumentoRepository alunoInstrumentoRepository;
+    private final AlunoMetodoRepository alunoMetodoRepository;
+    private final AdminRepository adminRepository;
+    private final InstrutorRepository instrutorRepository;
+    private final InstrumentoRepository instrumentoRepository;
+    private final MetodoRepository metodoRepository;
+    private final RegistroAulaRepository registroAulaRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public DataSeeder(
             ComumRepository comumRepository,
             PessoaRepository pessoaRepository,
             AlunoRepository alunoRepository,
+            AlunoInstrumentoRepository alunoInstrumentoRepository,
+            AlunoMetodoRepository alunoMetodoRepository,
             AdminRepository adminRepository,
             InstrutorRepository instrutorRepository,
             InstrumentoRepository instrumentoRepository,
             MetodoRepository metodoRepository,
-            RegistroAulaRepository registroAulaRepository
+            RegistroAulaRepository registroAulaRepository,
+            PasswordEncoder passwordEncoder
     ) {
-        return args -> {
-            if (comumRepository.count() > 0
-                    || pessoaRepository.count() > 0
-                    || alunoRepository.count() > 0
-                    || adminRepository.count() > 0
-                    || instrutorRepository.count() > 0
-                    || instrumentoRepository.count() > 0
-                    || metodoRepository.count() > 0
-                    || registroAulaRepository.count() > 0) {
-                logger.info("Seed ignorada: banco já possui dados.");
-                return;
-            }
-
-            Comum comumCentral = criarComum(
-                    "Central",
-                    "Campo Mourão",
-                    "PR",
-                    "Centro",
-                    "Rua Brasil",
-                    "100"
-            );
-
-            Comum comumJardim = criarComum(
-                    "Jardim Tropical",
-                    "Campo Mourão",
-                    "PR",
-                    "Jardim Tropical",
-                    "Avenida das Flores",
-                    "250"
-            );
-
-            comumRepository.saveAll(List.of(comumCentral, comumJardim));
-
-            Pessoa pessoaAluno1 = criarPessoa("11111111111", "João da Silva", comumCentral);
-            Pessoa pessoaAluno2 = criarPessoa("22222222222", "Maria Oliveira", comumCentral);
-            Pessoa pessoaAluno3 = criarPessoa("33333333333", "Pedro Santos", comumJardim);
-
-            Pessoa pessoaInstrutor1 = criarPessoa("44444444444", "Carlos Instrutor", comumCentral);
-            Pessoa pessoaInstrutor2 = criarPessoa("55555555555", "Ana Instrutora", comumJardim);
-
-            Pessoa pessoaAdmin = criarPessoa("00000000001", "Administrador GEM", comumCentral);
-
-            pessoaRepository.saveAll(List.of(
-                    pessoaAluno1,
-                    pessoaAluno2,
-                    pessoaAluno3,
-                    pessoaInstrutor1,
-                    pessoaInstrutor2,
-                    pessoaAdmin
-            ));
-
-            Aluno aluno1 = criarAluno("$2a$12$M0cwptYjFvAN5icWicqIo.Ls4GjCpuPONrfJPEiwdPePjueM1X69q", pessoaAluno1, comumCentral);
-            Aluno aluno2 = criarAluno("$2a$12$M0cwptYjFvAN5icWicqIo.Ls4GjCpuPONrfJPEiwdPePjueM1X69q", pessoaAluno2, comumCentral);
-            Aluno aluno3 = criarAluno("$2a$12$M0cwptYjFvAN5icWicqIo.Ls4GjCpuPONrfJPEiwdPePjueM1X69q", pessoaAluno3, comumJardim);
-
-            alunoRepository.saveAll(List.of(aluno1, aluno2, aluno3));
-
-            Instrutor instrutor1 = criarInstrutor("$2a$12$M0cwptYjFvAN5icWicqIo.Ls4GjCpuPONrfJPEiwdPePjueM1X69q", pessoaInstrutor1);
-            Instrutor instrutor2 = criarInstrutor("$2a$12$M0cwptYjFvAN5icWicqIo.Ls4GjCpuPONrfJPEiwdPePjueM1X69q", pessoaInstrutor2);
-
-            instrutorRepository.saveAll(List.of(instrutor1, instrutor2));
-
-            Admin admin = criarAdmin("$2a$12$klTvMCuhc40EUESyz0MM6uIgSfzIMyk/K3Ff592DEsj52cfGZbgPi", pessoaAdmin);
-
-            adminRepository.save(admin);
-
-            Instrumento violino = criarInstrumento("Violino");
-            Instrumento trompete = criarInstrumento("Trompete");
-            Instrumento saxofone = criarInstrumento("Saxofone");
-
-            instrumentoRepository.saveAll(List.of(
-                    violino,
-                    trompete,
-                    saxofone
-            ));
-
-            Metodo metodoViolinoAluno1 = criarMetodo(
-                    "Método básico de violino",
-                    violino,
-                    aluno1
-            );
-
-            Metodo metodoTrompeteAluno2 = criarMetodo(
-                    "Iniciação ao trompete",
-                    trompete,
-                    aluno2
-            );
-
-            Metodo metodoSaxofoneAluno3 = criarMetodo(
-                    "Saxofone para iniciantes",
-                    saxofone,
-                    aluno3
-            );
-
-            metodoRepository.saveAll(List.of(
-                    metodoViolinoAluno1,
-                    metodoTrompeteAluno2,
-                    metodoSaxofoneAluno3
-            ));
-
-            RegistroAula aula1 = criarRegistroAula(
-                    aluno1,
-                    instrutor1,
-                    LocalDate.now().minusDays(7),
-                    (short) 1,
-                    "Primeira aula de violino: postura, empunhadura do arco e exercícios com cordas soltas.",
-                    "Treinar cordas soltas com arco inteiro e revisar postura diante do espelho."
-            );
-
-            RegistroAula aula2 = criarRegistroAula(
-                    aluno2,
-                    instrutor1,
-                    LocalDate.now().minusDays(5),
-                    (short) 1,
-                    "Primeira aula de trompete: respiração, embocadura e emissão das primeiras notas.",
-                    "Praticar notas longas com foco em estabilidade de som e respiração."
-            );
-
-            RegistroAula aula3 = criarRegistroAula(
-                    aluno3,
-                    instrutor2,
-                    LocalDate.now().minusDays(3),
-                    (short) 1,
-                    "Primeira aula de saxofone: montagem do instrumento, postura e emissão inicial do som.",
-                    "Praticar emissão de som com boquilha e palheta, mantendo coluna de ar constante."
-            );
-
-            registroAulaRepository.saveAll(List.of(
-                    aula1,
-                    aula2,
-                    aula3
-            ));
-
-            logger.info("Seed executada com sucesso.");
-        };
+        this.comumRepository = comumRepository;
+        this.pessoaRepository = pessoaRepository;
+        this.alunoRepository = alunoRepository;
+        this.alunoInstrumentoRepository = alunoInstrumentoRepository;
+        this.alunoMetodoRepository = alunoMetodoRepository;
+        this.adminRepository = adminRepository;
+        this.instrutorRepository = instrutorRepository;
+        this.instrumentoRepository = instrumentoRepository;
+        this.metodoRepository = metodoRepository;
+        this.registroAulaRepository = registroAulaRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
-    private Comum criarComum(
+    @Override
+    @Transactional
+    public void run(String... args) {
+        logger.info("Verificando dados de desenvolvimento da seed...");
+
+        Comum comumCentral = garantirComum(
+                "Central",
+                "Campo Mourão",
+                "PR",
+                "Centro",
+                "Rua Brasil",
+                "100"
+        );
+        Comum comumJardim = garantirComum(
+                "Jardim Tropical",
+                "Campo Mourão",
+                "PR",
+                "Jardim Tropical",
+                "Avenida das Flores",
+                "250"
+        );
+
+        Pessoa pessoaAluno1 = garantirPessoa("11111111111", "João da Silva", comumCentral);
+        Pessoa pessoaAluno2 = garantirPessoa("22222222222", "Maria Oliveira", comumCentral);
+        Pessoa pessoaAluno3 = garantirPessoa("33333333333", "Pedro Santos", comumJardim);
+        Pessoa pessoaInstrutor1 = garantirPessoa("44444444444", "Carlos Instrutor", comumCentral);
+        Pessoa pessoaInstrutor2 = garantirPessoa("55555555555", "Ana Instrutora", comumJardim);
+        Pessoa pessoaAdmin = garantirPessoa("00000000001", "Administrador GEM", comumCentral);
+
+        Aluno aluno1 = garantirAluno(pessoaAluno1, comumCentral);
+        Aluno aluno2 = garantirAluno(pessoaAluno2, comumCentral);
+        Aluno aluno3 = garantirAluno(pessoaAluno3, comumJardim);
+        Instrutor instrutor1 = garantirInstrutor(pessoaInstrutor1);
+        Instrutor instrutor2 = garantirInstrutor(pessoaInstrutor2);
+        garantirAdmin(pessoaAdmin);
+
+        Instrumento violino = garantirInstrumento("Violino");
+        Instrumento trompete = garantirInstrumento("Trompete");
+        Instrumento saxofone = garantirInstrumento("Saxofone");
+
+        garantirAlunoInstrumento(aluno1, violino, true);
+        garantirAlunoInstrumento(aluno1, saxofone, false);
+        garantirAlunoInstrumento(aluno2, trompete, true);
+        garantirAlunoInstrumento(aluno3, saxofone, true);
+
+        Metodo metodoViolino = garantirMetodo("Método básico de violino", violino);
+        Metodo metodoTrompete = garantirMetodo("Iniciação ao trompete", trompete);
+        Metodo metodoSaxofone = garantirMetodo("Saxofone para iniciantes", saxofone);
+
+        garantirAlunoMetodo(aluno1, metodoViolino);
+        garantirAlunoMetodo(aluno1, metodoSaxofone);
+        garantirAlunoMetodo(aluno2, metodoTrompete);
+        garantirAlunoMetodo(aluno3, metodoSaxofone);
+
+        garantirRegistroAula(
+                aluno1,
+                instrutor1,
+                LocalDate.now().minusDays(7),
+                "Primeira aula de violino: postura, empunhadura do arco e exercícios com cordas soltas.",
+                "Treinar cordas soltas com arco inteiro e revisar postura diante do espelho."
+        );
+        garantirRegistroAula(
+                aluno2,
+                instrutor1,
+                LocalDate.now().minusDays(5),
+                "Primeira aula de trompete: respiração, embocadura e emissão das primeiras notas.",
+                "Praticar notas longas com foco em estabilidade de som e respiração."
+        );
+        garantirRegistroAula(
+                aluno3,
+                instrutor2,
+                LocalDate.now().minusDays(3),
+                "Primeira aula de saxofone: montagem do instrumento, postura e emissão inicial do som.",
+                "Praticar emissão de som com boquilha e palheta, mantendo coluna de ar constante."
+        );
+
+        logger.info("Seed de desenvolvimento verificada com sucesso.");
+    }
+
+    private Comum garantirComum(
             String nome,
             String cidade,
             String estado,
@@ -188,75 +163,131 @@ public class DataSeeder {
             String logradouro,
             String numero
     ) {
-        Comum comum = new Comum();
-        comum.setNome(nome);
-        comum.setCidade(cidade);
-        comum.setEstado(estado);
-        comum.setBairro(bairro);
-        comum.setLogradouro(logradouro);
-        comum.setNumero(numero);
-        return comum;
+        return comumRepository.findByNomeAndCidade(nome, cidade).orElseGet(() -> {
+            Comum comum = new Comum();
+            comum.setNome(nome);
+            comum.setCidade(cidade);
+            comum.setEstado(estado);
+            comum.setBairro(bairro);
+            comum.setLogradouro(logradouro);
+            comum.setNumero(numero);
+            return comumRepository.save(comum);
+        });
     }
 
-    private Pessoa criarPessoa(String cpf, String nome, Comum comum) {
-        Pessoa pessoa = new Pessoa();
-        pessoa.setCpf(cpf);
-        pessoa.setNome(nome);
-        pessoa.setComum(comum);
-        return pessoa;
+    private Pessoa garantirPessoa(String cpf, String nome, Comum comum) {
+        return pessoaRepository.findById(cpf).orElseGet(() -> {
+            Pessoa pessoa = new Pessoa();
+            pessoa.setCpf(cpf);
+            pessoa.setNome(nome);
+            pessoa.setComum(comum);
+            return pessoaRepository.save(pessoa);
+        });
     }
 
-    private Aluno criarAluno(String senha, Pessoa pessoa, Comum comum) {
-        Aluno aluno = new Aluno();
-        aluno.setSenha(senha);
-        aluno.setPessoa(pessoa);
-        aluno.setComum(comum);
-        return aluno;
+    private Aluno garantirAluno(Pessoa pessoa, Comum comum) {
+        return alunoRepository.findByPessoa_Cpf(pessoa.getCpf()).orElseGet(() -> {
+            Aluno aluno = new Aluno();
+            aluno.setSenha(passwordEncoder.encode(SENHA_USUARIO));
+            aluno.setPessoa(pessoa);
+            aluno.setComum(comum);
+            return alunoRepository.save(aluno);
+        });
     }
 
-    private Instrutor criarInstrutor(String senha, Pessoa pessoa) {
-        Instrutor instrutor = new Instrutor();
-        instrutor.setSenha(senha);
-        instrutor.setPessoa(pessoa);
-        return instrutor;
+    private Instrutor garantirInstrutor(Pessoa pessoa) {
+        return instrutorRepository.findByPessoa_Cpf(pessoa.getCpf()).orElseGet(() -> {
+            Instrutor instrutor = new Instrutor();
+            instrutor.setSenha(passwordEncoder.encode(SENHA_USUARIO));
+            instrutor.setPessoa(pessoa);
+            return instrutorRepository.save(instrutor);
+        });
     }
 
-    private Admin criarAdmin(String senha, Pessoa pessoa) {
-        Admin admin = new Admin();
-        admin.setSenha(senha);
-        admin.setPessoa(pessoa);
-        return admin;
+    private void garantirAdmin(Pessoa pessoa) {
+        adminRepository.findByPessoa_Cpf(pessoa.getCpf()).orElseGet(() -> {
+            Admin admin = new Admin();
+            admin.setSenha(passwordEncoder.encode(SENHA_ADMIN));
+            admin.setPessoa(pessoa);
+            return adminRepository.save(admin);
+        });
     }
 
-    private Instrumento criarInstrumento(String nome) {
-        Instrumento instrumento = new Instrumento();
-        instrumento.setNome(nome);
-        return instrumento;
+    private Instrumento garantirInstrumento(String nome) {
+        return instrumentoRepository.findByNome(nome).orElseGet(() -> {
+            Instrumento instrumento = new Instrumento();
+            instrumento.setNome(nome);
+            return instrumentoRepository.save(instrumento);
+        });
     }
 
-    private Metodo criarMetodo(String nome, Instrumento instrumento, Aluno aluno) {
-        Metodo metodo = new Metodo();
-        metodo.setNome(nome);
-        metodo.setInstrumento(instrumento);
-        metodo.setAluno(aluno);
-        return metodo;
+    private Metodo garantirMetodo(String nome, Instrumento instrumento) {
+        return metodoRepository.findByNomeAndInstrumento_Id(nome, instrumento.getId()).orElseGet(() -> {
+            Metodo metodo = new Metodo();
+            metodo.setNome(nome);
+            metodo.setInstrumento(instrumento);
+            return metodoRepository.save(metodo);
+        });
     }
 
-    private RegistroAula criarRegistroAula(
+    private void garantirAlunoInstrumento(Aluno aluno, Instrumento instrumento, boolean principalDesejado) {
+        var vinculoExistente = alunoInstrumentoRepository
+                .findByAluno_IdAndInstrumento_Id(aluno.getId(), instrumento.getId());
+
+        if (vinculoExistente.isPresent()) {
+            AlunoInstrumento vinculo = vinculoExistente.get();
+            boolean semPrincipal = alunoInstrumentoRepository
+                    .findByAluno_IdOrderByInstrumento_NomeAsc(aluno.getId())
+                    .stream()
+                    .noneMatch(item -> item.getEhInstrumentoPrincipal() == 1);
+            if (principalDesejado && semPrincipal) {
+                vinculo.setEhInstrumentoPrincipal((short) 1);
+                alunoInstrumentoRepository.save(vinculo);
+            }
+            return;
+        }
+
+        boolean jaPossuiPrincipal = alunoInstrumentoRepository
+                .findByAluno_IdOrderByInstrumento_NomeAsc(aluno.getId())
+                .stream()
+                .anyMatch(item -> item.getEhInstrumentoPrincipal() == 1);
+
+        AlunoInstrumento vinculo = new AlunoInstrumento();
+        vinculo.setAluno(aluno);
+        vinculo.setInstrumento(instrumento);
+        vinculo.setEhInstrumentoPrincipal(principalDesejado && !jaPossuiPrincipal ? (short) 1 : (short) 0);
+        alunoInstrumentoRepository.save(vinculo);
+    }
+
+    private void garantirAlunoMetodo(Aluno aluno, Metodo metodo) {
+        if (alunoMetodoRepository.existsByAluno_IdAndMetodo_Id(aluno.getId(), metodo.getId())) {
+            return;
+        }
+
+        AlunoMetodo vinculo = new AlunoMetodo();
+        vinculo.setAluno(aluno);
+        vinculo.setMetodo(metodo);
+        alunoMetodoRepository.save(vinculo);
+    }
+
+    private void garantirRegistroAula(
             Aluno aluno,
             Instrutor instrutor,
             LocalDate data,
-            Short presente,
             String descricao,
             String paraProximaAula
     ) {
-        RegistroAula registroAula = new RegistroAula();
-        registroAula.setAluno(aluno);
-        registroAula.setInstrutor(instrutor);
-        registroAula.setData(data);
-        registroAula.setPresente(presente);
-        registroAula.setDescricao(descricao);
-        registroAula.setParaProximaAula(paraProximaAula);
-        return registroAula;
+        if (registroAulaRepository.existsByAluno_IdAndDescricao(aluno.getId(), descricao)) {
+            return;
+        }
+
+        RegistroAula registro = new RegistroAula();
+        registro.setAluno(aluno);
+        registro.setInstrutor(instrutor);
+        registro.setData(data);
+        registro.setPresente((short) 1);
+        registro.setDescricao(descricao);
+        registro.setParaProximaAula(paraProximaAula);
+        registroAulaRepository.save(registro);
     }
 }

--- a/backend/src/main/java/com/gem/backend/controller/AlunoController.java
+++ b/backend/src/main/java/com/gem/backend/controller/AlunoController.java
@@ -9,7 +9,7 @@ package com.gem.backend.controller;
  * @author leonardo
  */
 import com.gem.backend.dto.AlunoResponseDTO;
-import com.gem.backend.model.Aluno;
+import com.gem.backend.dto.AlunoRequestDTO;
 import com.gem.backend.service.AlunoService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -32,7 +32,7 @@ public class AlunoController {
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMIN','INSTRUTOR')")
-    public ResponseEntity<AlunoResponseDTO> create(@Valid @RequestBody Aluno aluno) {
+    public ResponseEntity<AlunoResponseDTO> create(@Valid @RequestBody AlunoRequestDTO aluno) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.createAluno(aluno));
     }
 
@@ -56,7 +56,10 @@ public class AlunoController {
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','INSTRUTOR')")
-    public ResponseEntity<AlunoResponseDTO> update(@PathVariable Long id, @RequestBody Aluno aluno) {
+    public ResponseEntity<AlunoResponseDTO> update(
+            @PathVariable Long id,
+            @Valid @RequestBody AlunoRequestDTO aluno
+    ) {
         return ResponseEntity.ok(service.updateAluno(id, aluno));
     }
 

--- a/backend/src/main/java/com/gem/backend/dto/AlunoInstrumentoRequestDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/AlunoInstrumentoRequestDTO.java
@@ -1,0 +1,9 @@
+package com.gem.backend.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AlunoInstrumentoRequestDTO(
+        @NotNull(message = "Informe o ID do instrumento.") Integer instrumentoId,
+        @NotNull(message = "Informe se o instrumento é o principal.") Boolean principal
+) {
+}

--- a/backend/src/main/java/com/gem/backend/dto/AlunoInstrumentoResponseDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/AlunoInstrumentoResponseDTO.java
@@ -1,0 +1,14 @@
+package com.gem.backend.dto;
+
+import com.gem.backend.model.AlunoInstrumento;
+
+public record AlunoInstrumentoResponseDTO(Integer id, String nome, boolean principal) {
+
+    public AlunoInstrumentoResponseDTO(AlunoInstrumento alunoInstrumento) {
+        this(
+                alunoInstrumento.getInstrumento().getId(),
+                alunoInstrumento.getInstrumento().getNome(),
+                alunoInstrumento.getEhInstrumentoPrincipal() == 1
+        );
+    }
+}

--- a/backend/src/main/java/com/gem/backend/dto/AlunoRequestDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/AlunoRequestDTO.java
@@ -1,0 +1,18 @@
+package com.gem.backend.dto;
+
+import com.gem.backend.model.Comum;
+import com.gem.backend.model.Pessoa;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AlunoRequestDTO(
+        @Size(max = 255, message = "Senha deve ter no máximo 255 caracteres.") String senha,
+        Pessoa pessoa,
+        Comum comum,
+        List<@NotNull(message = "Informe um instrumento válido.") @Valid AlunoInstrumentoRequestDTO> instrumentos,
+        List<Integer> metodoIds
+) {
+}

--- a/backend/src/main/java/com/gem/backend/dto/AlunoResponseDTO.java
+++ b/backend/src/main/java/com/gem/backend/dto/AlunoResponseDTO.java
@@ -3,6 +3,8 @@ package com.gem.backend.dto;
 import com.gem.backend.model.Aluno;
 import com.gem.backend.model.Comum;
 
+import java.util.List;
+
 public record AlunoResponseDTO(
         Long id,
         String cpf,
@@ -10,9 +12,15 @@ public record AlunoResponseDTO(
         Integer comumId,
         String comumNome,
         String comumCidade,
-        String comumUF
+        String comumUF,
+        List<AlunoInstrumentoResponseDTO> instrumentos,
+        List<MetodoResponseDTO> metodos
 ) {
-    public AlunoResponseDTO(Aluno aluno) {
+    public AlunoResponseDTO(
+            Aluno aluno,
+            List<AlunoInstrumentoResponseDTO> instrumentos,
+            List<MetodoResponseDTO> metodos
+    ) {
         this(
                 aluno.getId(),
                 aluno.getPessoa() != null ? aluno.getPessoa().getCpf() : null,
@@ -20,7 +28,9 @@ public record AlunoResponseDTO(
                 getComum(aluno) != null ? getComum(aluno).getId() : null,
                 getComum(aluno) != null ? getComum(aluno).getNome() : "",
                 getComum(aluno) != null ? getComum(aluno).getCidade() : "",
-                getComum(aluno) != null ? getComum(aluno).getEstado() : ""
+                getComum(aluno) != null ? getComum(aluno).getEstado() : "",
+                instrumentos,
+                metodos
         );
     }
 

--- a/backend/src/main/java/com/gem/backend/model/AlunoInstrumento.java
+++ b/backend/src/main/java/com/gem/backend/model/AlunoInstrumento.java
@@ -14,7 +14,13 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 @Entity
-@Table(name = "alunos_has_instrumentos")
+@Table(
+        name = "alunos_has_instrumentos",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_aluno_instrumento",
+                columnNames = {"aluno_id", "instrumento_id"}
+        )
+)
 public class AlunoInstrumento {
 
     @Id
@@ -23,18 +29,18 @@ public class AlunoInstrumento {
 
     @NotNull(message = "Aluno é obrigatório.")
     @ManyToOne
-    @JoinColumn(name = "aluno_id")
+    @JoinColumn(name = "aluno_id", nullable = false)
     private Aluno aluno;
 
     @NotNull(message = "Instrumento é obrigatório.")
     @ManyToOne
-    @JoinColumn(name = "instrumento_id")
+    @JoinColumn(name = "instrumento_id", nullable = false)
     private Instrumento instrumento;
 
     @NotNull(message = "Informe se é o instrumento principal.")
     @Min(value = 0, message = "Instrumento principal deve ser 0 ou 1.")
     @Max(value = 1, message = "Instrumento principal deve ser 0 ou 1.")
-    @Column(name = "eh_instrumento_principal")
+    @Column(name = "eh_instrumento_principal", nullable = false)
     private Short ehInstrumentoPrincipal;
 
     public AlunoInstrumento() {

--- a/backend/src/main/java/com/gem/backend/model/AlunoMetodo.java
+++ b/backend/src/main/java/com/gem/backend/model/AlunoMetodo.java
@@ -1,0 +1,60 @@
+package com.gem.backend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+
+@Entity
+@Table(
+        name = "alunos_has_metodos",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_aluno_metodo",
+                columnNames = {"aluno_id", "metodo_id"}
+        )
+)
+public class AlunoMetodo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @NotNull(message = "Aluno é obrigatório.")
+    @ManyToOne
+    @JoinColumn(name = "aluno_id", nullable = false)
+    private Aluno aluno;
+
+    @NotNull(message = "Método é obrigatório.")
+    @ManyToOne
+    @JoinColumn(name = "metodo_id", nullable = false)
+    private Metodo metodo;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Aluno getAluno() {
+        return aluno;
+    }
+
+    public void setAluno(Aluno aluno) {
+        this.aluno = aluno;
+    }
+
+    public Metodo getMetodo() {
+        return metodo;
+    }
+
+    public void setMetodo(Metodo metodo) {
+        this.metodo = metodo;
+    }
+}

--- a/backend/src/main/java/com/gem/backend/repository/AlunoInstrumentoRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/AlunoInstrumentoRepository.java
@@ -1,0 +1,18 @@
+package com.gem.backend.repository;
+
+import com.gem.backend.model.AlunoInstrumento;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AlunoInstrumentoRepository extends JpaRepository<AlunoInstrumento, Integer> {
+
+    List<AlunoInstrumento> findByAluno_IdOrderByInstrumento_NomeAsc(Long alunoId);
+
+    Optional<AlunoInstrumento> findByAluno_IdAndInstrumento_Id(Long alunoId, Integer instrumentoId);
+
+    void deleteByAluno_Id(Long alunoId);
+}

--- a/backend/src/main/java/com/gem/backend/repository/AlunoMetodoRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/AlunoMetodoRepository.java
@@ -1,0 +1,17 @@
+package com.gem.backend.repository;
+
+import com.gem.backend.model.AlunoMetodo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AlunoMetodoRepository extends JpaRepository<AlunoMetodo, Integer> {
+
+    List<AlunoMetodo> findByAluno_IdOrderByMetodo_NomeAsc(Long alunoId);
+
+    boolean existsByAluno_IdAndMetodo_Id(Long alunoId, Integer metodoId);
+
+    void deleteByAluno_Id(Long alunoId);
+}

--- a/backend/src/main/java/com/gem/backend/repository/ComumRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/ComumRepository.java
@@ -12,7 +12,9 @@ import com.gem.backend.model.Comum;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ComumRepository extends JpaRepository<Comum, Integer> {
-
+    Optional<Comum> findByNomeAndCidade(String nome, String cidade);
 }

--- a/backend/src/main/java/com/gem/backend/repository/InstrumentoRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/InstrumentoRepository.java
@@ -13,5 +13,9 @@ import com.gem.backend.model.Instrumento;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface InstrumentoRepository extends JpaRepository<Instrumento, Integer> {}
+public interface InstrumentoRepository extends JpaRepository<Instrumento, Integer> {
+    Optional<Instrumento> findByNome(String nome);
+}

--- a/backend/src/main/java/com/gem/backend/repository/MetodoRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/MetodoRepository.java
@@ -13,6 +13,12 @@ import com.gem.backend.model.Metodo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface MetodoRepository extends JpaRepository<Metodo, Integer> {
+    List<Metodo> findByAluno_Id(Long alunoId);
+
+    Optional<Metodo> findByNomeAndInstrumento_Id(String nome, Integer instrumentoId);
 }

--- a/backend/src/main/java/com/gem/backend/repository/RegistroAulaRepository.java
+++ b/backend/src/main/java/com/gem/backend/repository/RegistroAulaRepository.java
@@ -21,4 +21,6 @@ public interface RegistroAulaRepository extends JpaRepository<RegistroAula, Inte
     List<RegistroAula> findAllByOrderByDataDescIdDesc();
 
     List<RegistroAula> findByAluno_Pessoa_CpfOrderByDataDescIdDesc(String cpf);
+
+    boolean existsByAluno_IdAndDescricao(Long alunoId, String descricao);
 }

--- a/backend/src/main/java/com/gem/backend/service/AlunoService.java
+++ b/backend/src/main/java/com/gem/backend/service/AlunoService.java
@@ -1,22 +1,40 @@
 package com.gem.backend.service;
 
+import com.gem.backend.dto.AlunoInstrumentoRequestDTO;
+import com.gem.backend.dto.AlunoInstrumentoResponseDTO;
+import com.gem.backend.dto.AlunoRequestDTO;
 import com.gem.backend.dto.AlunoResponseDTO;
+import com.gem.backend.dto.MetodoResponseDTO;
 import com.gem.backend.exception.BadRequestException;
 import com.gem.backend.exception.DuplicateResourceException;
 import com.gem.backend.exception.ResourceNotFoundException;
 import com.gem.backend.model.Aluno;
+import com.gem.backend.model.AlunoInstrumento;
+import com.gem.backend.model.AlunoMetodo;
 import com.gem.backend.model.Comum;
+import com.gem.backend.model.Instrumento;
+import com.gem.backend.model.Metodo;
 import com.gem.backend.model.Pessoa;
+import com.gem.backend.repository.AlunoInstrumentoRepository;
+import com.gem.backend.repository.AlunoMetodoRepository;
 import com.gem.backend.repository.AlunoRepository;
 import com.gem.backend.repository.ComumRepository;
+import com.gem.backend.repository.InstrumentoRepository;
+import com.gem.backend.repository.MetodoRepository;
 import com.gem.backend.repository.PessoaRepository;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 public class AlunoService {
@@ -24,123 +42,249 @@ public class AlunoService {
     private final AlunoRepository repository;
     private final PessoaRepository pessoaRepository;
     private final ComumRepository comumRepository;
+    private final InstrumentoRepository instrumentoRepository;
+    private final MetodoRepository metodoRepository;
+    private final AlunoInstrumentoRepository alunoInstrumentoRepository;
+    private final AlunoMetodoRepository alunoMetodoRepository;
     private final PasswordEncoder passwordEncoder;
 
     public AlunoService(
             AlunoRepository repository,
             PessoaRepository pessoaRepository,
             ComumRepository comumRepository,
+            InstrumentoRepository instrumentoRepository,
+            MetodoRepository metodoRepository,
+            AlunoInstrumentoRepository alunoInstrumentoRepository,
+            AlunoMetodoRepository alunoMetodoRepository,
             PasswordEncoder passwordEncoder
     ) {
         this.repository = repository;
         this.pessoaRepository = pessoaRepository;
         this.comumRepository = comumRepository;
+        this.instrumentoRepository = instrumentoRepository;
+        this.metodoRepository = metodoRepository;
+        this.alunoInstrumentoRepository = alunoInstrumentoRepository;
+        this.alunoMetodoRepository = alunoMetodoRepository;
         this.passwordEncoder = passwordEncoder;
     }
 
-    public AlunoResponseDTO createAluno(Aluno aluno) {
-        if (aluno.getId() != null && repository.existsById(aluno.getId())) {
-            throw new DuplicateResourceException("Já existe um aluno cadastrado com este ID.");
-        }
-
-        Pessoa pessoa = buscarPessoaObrigatoria(aluno);
+    @Transactional
+    public AlunoResponseDTO createAluno(AlunoRequestDTO dados) {
+        Pessoa pessoa = buscarPessoaObrigatoria(dados.pessoa());
 
         if (repository.existsByPessoa_Cpf(pessoa.getCpf())) {
             throw new DuplicateResourceException("Já existe um aluno cadastrado para este CPF.");
         }
 
-        aluno.setPessoa(pessoa);
-        aluno.setSenha(passwordEncoder.encode(aluno.getSenha()));
-
-        if (aluno.getComum() != null && aluno.getComum().getId() != null) {
-            Comum comum = comumRepository.findById(aluno.getComum().getId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Comum não encontrada."));
-
-            aluno.setComum(comum);
+        if (dados.senha() == null || dados.senha().isBlank()) {
+            throw new BadRequestException("Senha é obrigatória.");
         }
 
+        Aluno aluno = new Aluno();
+        aluno.setPessoa(pessoa);
+        aluno.setSenha(passwordEncoder.encode(dados.senha()));
+        definirComum(aluno, dados.comum());
+
         Aluno alunoSalvo = repository.save(aluno);
-        return new AlunoResponseDTO(alunoSalvo);
+        sincronizarInstrumentos(alunoSalvo, dados.instrumentos());
+        sincronizarMetodos(alunoSalvo, dados.metodoIds());
+        return toResponse(alunoSalvo);
     }
 
+    @Transactional(readOnly = true)
     public List<AlunoResponseDTO> getListAluno() {
-        return repository.findAll().stream()
-                .map(AlunoResponseDTO::new)
-                .toList();
+        return repository.findAll().stream().map(this::toResponse).toList();
     }
 
+    @Transactional(readOnly = true)
     public AlunoResponseDTO getAluno(Long id) {
-        Aluno aluno = repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado."));
+        Aluno aluno = buscarAluno(id);
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String cpfLogado = auth.getName();
 
         boolean isAdminOuInstrutor = auth.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN") || a.getAuthority().equals("ROLE_INSTRUTOR"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN")
+                        || a.getAuthority().equals("ROLE_INSTRUTOR"));
 
         if (!isAdminOuInstrutor && !aluno.getPessoa().getCpf().equals(cpfLogado)) {
             throw new AccessDeniedException("Acesso negado: Você só pode acessar o seu próprio perfil.");
         }
 
-        return new AlunoResponseDTO(aluno);
+        return toResponse(aluno);
     }
 
+    @Transactional(readOnly = true)
     public AlunoResponseDTO getAlunoPorCpf(String cpf) {
         Aluno aluno = repository.findByPessoa_Cpf(cpf)
                 .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado."));
-
-        return new AlunoResponseDTO(aluno);
+        return toResponse(aluno);
     }
 
-    public AlunoResponseDTO updateAluno(Long id, Aluno dadosAtualizados) {
-        Aluno alunoExistente = repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado."));
+    @Transactional
+    public AlunoResponseDTO updateAluno(Long id, AlunoRequestDTO dados) {
+        Aluno alunoExistente = buscarAluno(id);
 
-        if (dadosAtualizados.getSenha() != null && !dadosAtualizados.getSenha().trim().isEmpty()) {
-            alunoExistente.setSenha(passwordEncoder.encode(dadosAtualizados.getSenha()));
+        if (dados.senha() != null && !dados.senha().isBlank()) {
+            alunoExistente.setSenha(passwordEncoder.encode(dados.senha()));
         }
 
-        if (dadosAtualizados.getPessoa() != null && dadosAtualizados.getPessoa().getCpf() != null) {
-            Pessoa pessoa = buscarPessoaObrigatoria(dadosAtualizados);
-
+        if (dados.pessoa() != null && dados.pessoa().getCpf() != null) {
+            Pessoa pessoa = buscarPessoaObrigatoria(dados.pessoa());
             boolean cpfMudou = alunoExistente.getPessoa() == null
                     || !pessoa.getCpf().equals(alunoExistente.getPessoa().getCpf());
 
             if (cpfMudou && repository.existsByPessoa_Cpf(pessoa.getCpf())) {
                 throw new DuplicateResourceException("Já existe um aluno cadastrado para este CPF.");
             }
-
             alunoExistente.setPessoa(pessoa);
         }
 
-        if (dadosAtualizados.getComum() != null && dadosAtualizados.getComum().getId() != null) {
-            Comum comum = comumRepository.findById(dadosAtualizados.getComum().getId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Comum não encontrada."));
-
-            alunoExistente.setComum(comum);
-        }
-
-        return new AlunoResponseDTO(repository.save(alunoExistente));
+        definirComum(alunoExistente, dados.comum());
+        repository.save(alunoExistente);
+        sincronizarInstrumentos(alunoExistente, dados.instrumentos());
+        sincronizarMetodos(alunoExistente, dados.metodoIds());
+        return toResponse(alunoExistente);
     }
 
+    @Transactional
     public void deleteAluno(Long id) {
-        if (!repository.existsById(id)) {
-            throw new ResourceNotFoundException("Aluno não encontrado.");
-        }
+        Aluno aluno = buscarAluno(id);
 
-        repository.deleteById(id);
+        alunoMetodoRepository.deleteByAluno_Id(id);
+        alunoInstrumentoRepository.deleteByAluno_Id(id);
+        alunoMetodoRepository.flush();
+        alunoInstrumentoRepository.flush();
+
+        List<Metodo> metodosLegados = metodoRepository.findByAluno_Id(id);
+        metodosLegados.forEach(metodo -> metodo.setAluno(null));
+        metodoRepository.saveAll(metodosLegados);
+        metodoRepository.flush();
+
+        repository.delete(aluno);
     }
 
-    private Pessoa buscarPessoaObrigatoria(Aluno aluno) {
-        if (aluno == null
-                || aluno.getPessoa() == null
-                || aluno.getPessoa().getCpf() == null
-                || aluno.getPessoa().getCpf().trim().isEmpty()) {
+    private void sincronizarInstrumentos(
+            Aluno aluno,
+            List<AlunoInstrumentoRequestDTO> instrumentosSolicitados
+    ) {
+        if (instrumentosSolicitados == null) {
+            return;
+        }
+        if (instrumentosSolicitados.isEmpty()) {
+            throw new BadRequestException("Selecione pelo menos um instrumento para o aluno.");
+        }
+
+        long quantidadePrincipais = instrumentosSolicitados.stream()
+                .filter(item -> Boolean.TRUE.equals(item.principal()))
+                .count();
+        if (quantidadePrincipais != 1) {
+            throw new BadRequestException("Selecione exatamente um instrumento principal.");
+        }
+
+        Set<Integer> idsUnicos = new HashSet<>();
+        List<AlunoInstrumento> novosVinculos = new ArrayList<>();
+
+        for (AlunoInstrumentoRequestDTO item : instrumentosSolicitados) {
+            if (!idsUnicos.add(item.instrumentoId())) {
+                throw new BadRequestException("Um instrumento não pode ser selecionado mais de uma vez.");
+            }
+
+            Instrumento instrumento = instrumentoRepository.findById(item.instrumentoId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Instrumento não encontrado."));
+
+            AlunoInstrumento vinculo = new AlunoInstrumento();
+            vinculo.setAluno(aluno);
+            vinculo.setInstrumento(instrumento);
+            vinculo.setEhInstrumentoPrincipal(Boolean.TRUE.equals(item.principal()) ? (short) 1 : (short) 0);
+            novosVinculos.add(vinculo);
+        }
+
+        alunoInstrumentoRepository.deleteByAluno_Id(aluno.getId());
+        alunoInstrumentoRepository.flush();
+        alunoInstrumentoRepository.saveAll(novosVinculos);
+    }
+
+    private void sincronizarMetodos(Aluno aluno, List<Integer> metodoIds) {
+        if (metodoIds == null) {
+            return;
+        }
+
+        Set<Integer> idsUnicos = new HashSet<>();
+        for (Integer metodoId : metodoIds) {
+            if (metodoId == null) {
+                throw new BadRequestException("Informe IDs de métodos válidos.");
+            }
+            if (!idsUnicos.add(metodoId)) {
+                throw new BadRequestException("Um método não pode ser selecionado mais de uma vez.");
+            }
+        }
+
+        List<Metodo> metodos = metodoRepository.findAllById(idsUnicos);
+        if (metodos.size() != idsUnicos.size()) {
+            throw new ResourceNotFoundException("Um ou mais métodos não foram encontrados.");
+        }
+
+        // Converte também os vínculos do modelo antigo (metodos.aluno_id) para a tabela associativa.
+        List<Metodo> metodosLegados = metodoRepository.findByAluno_Id(aluno.getId());
+        metodosLegados.forEach(metodo -> metodo.setAluno(null));
+        metodoRepository.saveAll(metodosLegados);
+
+        alunoMetodoRepository.deleteByAluno_Id(aluno.getId());
+        alunoMetodoRepository.flush();
+        List<AlunoMetodo> novosVinculos = metodos.stream().map(metodo -> {
+            AlunoMetodo vinculo = new AlunoMetodo();
+            vinculo.setAluno(aluno);
+            vinculo.setMetodo(metodo);
+            return vinculo;
+        }).toList();
+        alunoMetodoRepository.saveAll(novosVinculos);
+    }
+
+    private AlunoResponseDTO toResponse(Aluno aluno) {
+        List<AlunoInstrumentoResponseDTO> instrumentos = alunoInstrumentoRepository
+                .findByAluno_IdOrderByInstrumento_NomeAsc(aluno.getId())
+                .stream()
+                .map(AlunoInstrumentoResponseDTO::new)
+                .toList();
+
+        Map<Integer, Metodo> metodosPorId = new LinkedHashMap<>();
+        alunoMetodoRepository.findByAluno_IdOrderByMetodo_NomeAsc(aluno.getId())
+                .forEach(vinculo -> metodosPorId.put(vinculo.getMetodo().getId(), vinculo.getMetodo()));
+        metodoRepository.findByAluno_Id(aluno.getId())
+                .forEach(metodo -> metodosPorId.putIfAbsent(metodo.getId(), metodo));
+
+        List<MetodoResponseDTO> metodos = metodosPorId.values().stream()
+                .sorted((a, b) -> a.getNome().compareToIgnoreCase(b.getNome()))
+                .map(MetodoResponseDTO::new)
+                .toList();
+
+        return new AlunoResponseDTO(aluno, instrumentos, metodos);
+    }
+
+    private Aluno buscarAluno(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado."));
+    }
+
+    private Pessoa buscarPessoaObrigatoria(Pessoa pessoaInformada) {
+        if (pessoaInformada == null
+                || pessoaInformada.getCpf() == null
+                || pessoaInformada.getCpf().isBlank()) {
             throw new BadRequestException("Informe o CPF da pessoa vinculada ao aluno.");
         }
 
-        return pessoaRepository.findById(aluno.getPessoa().getCpf())
+        return pessoaRepository.findById(pessoaInformada.getCpf())
                 .orElseThrow(() -> new ResourceNotFoundException("Pessoa não encontrada."));
+    }
+
+    private void definirComum(Aluno aluno, Comum comumInformada) {
+        if (comumInformada == null || comumInformada.getId() == null) {
+            return;
+        }
+
+        Comum comum = comumRepository.findById(comumInformada.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Comum não encontrada."));
+        aluno.setComum(comum);
     }
 }

--- a/backend/src/test/java/com/gem/backend/config/DataSeederTest.java
+++ b/backend/src/test/java/com/gem/backend/config/DataSeederTest.java
@@ -1,0 +1,79 @@
+package com.gem.backend.config;
+
+import com.gem.backend.repository.AdminRepository;
+import com.gem.backend.repository.AlunoInstrumentoRepository;
+import com.gem.backend.repository.AlunoMetodoRepository;
+import com.gem.backend.repository.AlunoRepository;
+import com.gem.backend.repository.ComumRepository;
+import com.gem.backend.repository.InstrumentoRepository;
+import com.gem.backend.repository.InstrutorRepository;
+import com.gem.backend.repository.MetodoRepository;
+import com.gem.backend.repository.PessoaRepository;
+import com.gem.backend.repository.RegistroAulaRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@Transactional
+class DataSeederTest {
+
+    @Autowired
+    private DataSeeder dataSeeder;
+    @Autowired
+    private ComumRepository comumRepository;
+    @Autowired
+    private PessoaRepository pessoaRepository;
+    @Autowired
+    private AlunoRepository alunoRepository;
+    @Autowired
+    private InstrutorRepository instrutorRepository;
+    @Autowired
+    private AdminRepository adminRepository;
+    @Autowired
+    private InstrumentoRepository instrumentoRepository;
+    @Autowired
+    private MetodoRepository metodoRepository;
+    @Autowired
+    private AlunoInstrumentoRepository alunoInstrumentoRepository;
+    @Autowired
+    private AlunoMetodoRepository alunoMetodoRepository;
+    @Autowired
+    private RegistroAulaRepository registroAulaRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void deveCompletarDadosSemDuplicarAoExecutarNovamente() {
+        dataSeeder.run();
+
+        assertEquals(2, comumRepository.count());
+        assertEquals(6, pessoaRepository.count());
+        assertEquals(3, alunoRepository.count());
+        assertEquals(2, instrutorRepository.count());
+        assertEquals(1, adminRepository.count());
+        assertEquals(3, instrumentoRepository.count());
+        assertEquals(3, metodoRepository.count());
+        assertEquals(4, alunoInstrumentoRepository.count());
+        assertEquals(4, alunoMetodoRepository.count());
+        assertEquals(3, registroAulaRepository.count());
+
+        var aluno = alunoRepository.findByPessoa_Cpf("11111111111").orElseThrow();
+        assertEquals(2, alunoInstrumentoRepository
+                .findByAluno_IdOrderByInstrumento_NomeAsc(aluno.getId())
+                .size());
+        assertEquals(2, alunoMetodoRepository
+                .findByAluno_IdOrderByMetodo_NomeAsc(aluno.getId())
+                .size());
+
+        var admin = adminRepository.findByPessoa_Cpf("00000000001").orElseThrow();
+        assertTrue(passwordEncoder.matches("admin123", admin.getSenha()));
+    }
+}

--- a/backend/src/test/java/com/gem/backend/service/AlunoServiceTest.java
+++ b/backend/src/test/java/com/gem/backend/service/AlunoServiceTest.java
@@ -1,0 +1,175 @@
+package com.gem.backend.service;
+
+import com.gem.backend.dto.AlunoInstrumentoRequestDTO;
+import com.gem.backend.dto.AlunoRequestDTO;
+import com.gem.backend.exception.BadRequestException;
+import com.gem.backend.model.Aluno;
+import com.gem.backend.model.AlunoInstrumento;
+import com.gem.backend.model.AlunoMetodo;
+import com.gem.backend.model.Instrumento;
+import com.gem.backend.model.Metodo;
+import com.gem.backend.model.Pessoa;
+import com.gem.backend.repository.AlunoInstrumentoRepository;
+import com.gem.backend.repository.AlunoMetodoRepository;
+import com.gem.backend.repository.AlunoRepository;
+import com.gem.backend.repository.ComumRepository;
+import com.gem.backend.repository.InstrumentoRepository;
+import com.gem.backend.repository.MetodoRepository;
+import com.gem.backend.repository.PessoaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AlunoServiceTest {
+
+    @Mock
+    private AlunoRepository alunoRepository;
+    @Mock
+    private PessoaRepository pessoaRepository;
+    @Mock
+    private ComumRepository comumRepository;
+    @Mock
+    private InstrumentoRepository instrumentoRepository;
+    @Mock
+    private MetodoRepository metodoRepository;
+    @Mock
+    private AlunoInstrumentoRepository alunoInstrumentoRepository;
+    @Mock
+    private AlunoMetodoRepository alunoMetodoRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private AlunoService service;
+    private Aluno aluno;
+
+    @BeforeEach
+    void setUp() {
+        service = new AlunoService(
+                alunoRepository,
+                pessoaRepository,
+                comumRepository,
+                instrumentoRepository,
+                metodoRepository,
+                alunoInstrumentoRepository,
+                alunoMetodoRepository,
+                passwordEncoder
+        );
+
+        Pessoa pessoa = new Pessoa();
+        pessoa.setCpf("12345678901");
+        pessoa.setNome("Aluno Teste");
+
+        aluno = new Aluno();
+        aluno.setId(1L);
+        aluno.setPessoa(pessoa);
+        aluno.setSenha("senha-codificada");
+
+        when(alunoRepository.findById(1L)).thenReturn(Optional.of(aluno));
+        when(alunoRepository.save(any(Aluno.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void devePreservarMetodosDeInstrumentosDiferentesAoTrocarPrincipal() {
+        Instrumento violino = instrumento(10, "Violino");
+        Instrumento trompete = instrumento(20, "Trompete");
+        Metodo metodoViolino = metodo(100, "Método de violino", violino);
+        Metodo metodoTrompete = metodo(200, "Método de trompete", trompete);
+
+        when(instrumentoRepository.findById(10)).thenReturn(Optional.of(violino));
+        when(instrumentoRepository.findById(20)).thenReturn(Optional.of(trompete));
+        when(metodoRepository.findAllById(any())).thenReturn(List.of(metodoViolino, metodoTrompete));
+        when(alunoInstrumentoRepository.findByAluno_IdOrderByInstrumento_NomeAsc(1L))
+                .thenReturn(List.of());
+        when(alunoMetodoRepository.findByAluno_IdOrderByMetodo_NomeAsc(1L))
+                .thenReturn(List.of());
+        when(metodoRepository.findByAluno_Id(1L)).thenReturn(List.of());
+
+        AlunoRequestDTO request = new AlunoRequestDTO(
+                null,
+                null,
+                null,
+                List.of(
+                        new AlunoInstrumentoRequestDTO(10, false),
+                        new AlunoInstrumentoRequestDTO(20, true)
+                ),
+                List.of(100, 200)
+        );
+
+        service.updateAluno(1L, request);
+
+        ArgumentCaptor<Iterable<AlunoInstrumento>> instrumentoCaptor = captor();
+        verify(alunoInstrumentoRepository).saveAll(instrumentoCaptor.capture());
+        Set<Integer> principais = new HashSet<>();
+        for (AlunoInstrumento vinculo : instrumentoCaptor.getValue()) {
+            if (vinculo.getEhInstrumentoPrincipal() == 1) {
+                principais.add(vinculo.getInstrumento().getId());
+            }
+        }
+        assertEquals(Set.of(20), principais);
+
+        ArgumentCaptor<Iterable<AlunoMetodo>> metodoCaptor = captor();
+        verify(alunoMetodoRepository).saveAll(metodoCaptor.capture());
+        Set<Integer> metodosSalvos = new HashSet<>();
+        for (AlunoMetodo vinculo : metodoCaptor.getValue()) {
+            metodosSalvos.add(vinculo.getMetodo().getId());
+        }
+        assertEquals(Set.of(100, 200), metodosSalvos);
+    }
+
+    @Test
+    void deveRejeitarMaisDeUmInstrumentoPrincipal() {
+        AlunoRequestDTO request = new AlunoRequestDTO(
+                null,
+                null,
+                null,
+                List.of(
+                        new AlunoInstrumentoRequestDTO(10, true),
+                        new AlunoInstrumentoRequestDTO(20, true)
+                ),
+                List.of()
+        );
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> service.updateAluno(1L, request)
+        );
+
+        assertEquals("Selecione exatamente um instrumento principal.", exception.getMessage());
+    }
+
+    private Instrumento instrumento(int id, String nome) {
+        Instrumento instrumento = new Instrumento();
+        instrumento.setId(id);
+        instrumento.setNome(nome);
+        return instrumento;
+    }
+
+    private Metodo metodo(int id, String nome, Instrumento instrumento) {
+        Metodo metodo = new Metodo();
+        metodo.setId(id);
+        metodo.setNome(nome);
+        metodo.setInstrumento(instrumento);
+        return metodo;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private <T> ArgumentCaptor<Iterable<T>> captor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(Iterable.class);
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:sistema-gem;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false

--- a/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - backend
     ports:
-      - "3000:80"
+      - "${FRONTEND_PORT:-3000}:80"
 
 volumes:
   postgres_data:

--- a/frontend/lib/models/aluno.dart
+++ b/frontend/lib/models/aluno.dart
@@ -1,3 +1,6 @@
+import 'instrumento_aluno.dart';
+import 'metodo.dart';
+
 class Aluno {
   final int id;
   final String nome;
@@ -6,6 +9,8 @@ class Aluno {
   final String? comumNome;
   final String? comumCidade;
   final String? comumUF;
+  final List<InstrumentoAluno> instrumentos;
+  final List<Metodo> metodos;
 
   Aluno({
     required this.id,
@@ -15,6 +20,8 @@ class Aluno {
     this.comumNome,
     this.comumCidade,
     this.comumUF,
+    this.instrumentos = const [],
+    this.metodos = const [],
   });
 
   factory Aluno.fromJson(Map<String, dynamic> json) {
@@ -60,6 +67,14 @@ class Aluno {
           json['comumEstado']?.toString() ??
           comumObj?['uf']?.toString() ??
           comumObj?['estado']?.toString(),
+      instrumentos: (json['instrumentos'] as List? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(InstrumentoAluno.fromJson)
+          .toList(),
+      metodos: (json['metodos'] as List? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(Metodo.fromJson)
+          .toList(),
     );
   }
 
@@ -71,5 +86,12 @@ class Aluno {
     ].where((item) => item.trim().isNotEmpty).toList();
 
     return partes.isEmpty ? 'Sem comum' : partes.join(' - ');
+  }
+
+  InstrumentoAluno? get instrumentoPrincipal {
+    for (final instrumento in instrumentos) {
+      if (instrumento.principal) return instrumento;
+    }
+    return null;
   }
 }

--- a/frontend/lib/models/instrumento_aluno.dart
+++ b/frontend/lib/models/instrumento_aluno.dart
@@ -1,0 +1,19 @@
+class InstrumentoAluno {
+  final int id;
+  final String nome;
+  final bool principal;
+
+  InstrumentoAluno({
+    required this.id,
+    required this.nome,
+    required this.principal,
+  });
+
+  factory InstrumentoAluno.fromJson(Map<String, dynamic> json) {
+    return InstrumentoAluno(
+      id: json['id'],
+      nome: json['nome']?.toString() ?? '',
+      principal: json['principal'] == true,
+    );
+  }
+}

--- a/frontend/lib/services/aluno_service.dart
+++ b/frontend/lib/services/aluno_service.dart
@@ -44,10 +44,15 @@ class AlunoService {
   Future<void> criarAluno({
     required String cpf,
     required String senha,
+    required Set<int> instrumentoIds,
+    required int instrumentoPrincipalId,
+    required Set<int> metodoIds,
   }) async {
     final alunoBody = {
       "senha": senha,
       "pessoa": {"cpf": cpf},
+      "instrumentos": _instrumentosBody(instrumentoIds, instrumentoPrincipalId),
+      "metodoIds": metodoIds.toList(),
     };
 
     final alunoResponse = await ApiClient.post(
@@ -66,10 +71,15 @@ class AlunoService {
     required int id,
     required String cpf,
     String? senha,
+    required Set<int> instrumentoIds,
+    required int instrumentoPrincipalId,
+    required Set<int> metodoIds,
   }) async {
     final alunoBody = {
       "pessoa": {"cpf": cpf},
       if (senha != null && senha.trim().isNotEmpty) "senha": senha.trim(),
+      "instrumentos": _instrumentosBody(instrumentoIds, instrumentoPrincipalId),
+      "metodoIds": metodoIds.toList(),
     };
 
     final alunoResponse = await ApiClient.put(
@@ -96,12 +106,23 @@ class AlunoService {
   Future<Aluno> getAlunoById(int id) async {
     final response = await ApiClient.get('/alunos/$id');
 
-    ApiClient.ensureSuccess(
-      response,
-      fallbackMessage: 'Erro ao buscar aluno.',
-    );
+    ApiClient.ensureSuccess(response, fallbackMessage: 'Erro ao buscar aluno.');
 
     final data = jsonDecode(response.body);
     return Aluno.fromJson(data);
+  }
+
+  List<Map<String, dynamic>> _instrumentosBody(
+    Set<int> instrumentoIds,
+    int instrumentoPrincipalId,
+  ) {
+    return instrumentoIds
+        .map(
+          (id) => {
+            'instrumentoId': id,
+            'principal': id == instrumentoPrincipalId,
+          },
+        )
+        .toList();
   }
 }

--- a/frontend/lib/views/aluno_area/aluno_perfil_page.dart
+++ b/frontend/lib/views/aluno_area/aluno_perfil_page.dart
@@ -54,6 +54,8 @@ class _AlunoPerfilPageState extends State<AlunoPerfilPage> {
 
   @override
   Widget build(BuildContext context) {
+    final alunoAtual = aluno;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Perfil do aluno'),
@@ -77,7 +79,7 @@ class _AlunoPerfilPageState extends State<AlunoPerfilPage> {
                 ),
               ),
             )
-          : aluno == null
+          : alunoAtual == null
           ? const Center(child: Text('Aluno não encontrado.'))
           : ListView(
               padding: const EdgeInsets.all(16),
@@ -90,8 +92,8 @@ class _AlunoPerfilPageState extends State<AlunoPerfilPage> {
                         CircleAvatar(
                           radius: 34,
                           child: Text(
-                            aluno!.nome.isNotEmpty
-                                ? aluno!.nome[0].toUpperCase()
+                            alunoAtual.nome.isNotEmpty
+                                ? alunoAtual.nome[0].toUpperCase()
                                 : '?',
                             style: const TextStyle(fontSize: 28),
                           ),
@@ -99,7 +101,7 @@ class _AlunoPerfilPageState extends State<AlunoPerfilPage> {
                         const SizedBox(width: 16),
                         Expanded(
                           child: Text(
-                            aluno!.nome,
+                            alunoAtual.nome,
                             style: Theme.of(context).textTheme.titleLarge,
                           ),
                         ),
@@ -110,26 +112,146 @@ class _AlunoPerfilPageState extends State<AlunoPerfilPage> {
                 const SizedBox(height: 16),
                 _InfoCard(
                   titulo: 'CPF',
-                  valor: valorPadrao(aluno!.cpf),
+                  valor: valorPadrao(alunoAtual.cpf),
                   icone: Icons.badge,
                 ),
                 _InfoCard(
                   titulo: 'Comum',
-                  valor: valorPadrao(aluno!.comumCompleta),
+                  valor: valorPadrao(alunoAtual.comumCompleta),
                   icone: Icons.location_city,
                 ),
                 _InfoCard(
                   titulo: 'Cidade',
-                  valor: valorPadrao(aluno!.comumCidade),
+                  valor: valorPadrao(alunoAtual.comumCidade),
                   icone: Icons.location_on,
                 ),
                 _InfoCard(
                   titulo: 'Estado/UF',
-                  valor: valorPadrao(aluno!.comumUF),
+                  valor: valorPadrao(alunoAtual.comumUF),
                   icone: Icons.map,
                 ),
+                _InstrumentosCard(aluno: alunoAtual),
+                _MetodosInstrumentoPrincipalCard(aluno: alunoAtual),
               ],
             ),
+    );
+  }
+}
+
+class _InstrumentosCard extends StatelessWidget {
+  final Aluno aluno;
+
+  const _InstrumentosCard({required this.aluno});
+
+  @override
+  Widget build(BuildContext context) {
+    final instrumentos = [...aluno.instrumentos]
+      ..sort((a, b) {
+        if (a.principal == b.principal) {
+          return a.nome.toLowerCase().compareTo(b.nome.toLowerCase());
+        }
+        return a.principal ? -1 : 1;
+      });
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const ListTile(
+            leading: Icon(Icons.music_note),
+            title: Text('Instrumentos que toca'),
+          ),
+          if (instrumentos.isEmpty)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Text('Nenhum instrumento informado.'),
+            )
+          else
+            ...instrumentos.map(
+              (instrumento) => ListTile(
+                dense: true,
+                leading: Icon(
+                  instrumento.principal ? Icons.star : Icons.music_note,
+                  color: instrumento.principal
+                      ? Theme.of(context).colorScheme.primary
+                      : null,
+                ),
+                title: Text(instrumento.nome),
+                trailing: instrumento.principal
+                    ? const Chip(label: Text('Principal'))
+                    : null,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetodosInstrumentoPrincipalCard extends StatelessWidget {
+  final Aluno aluno;
+
+  const _MetodosInstrumentoPrincipalCard({required this.aluno});
+
+  @override
+  Widget build(BuildContext context) {
+    final instrumentoPrincipal = aluno.instrumentoPrincipal;
+
+    final metodos = instrumentoPrincipal == null
+        ? []
+        : aluno.metodos.where((metodo) {
+            final mesmoId =
+                metodo.instrumentoId != null &&
+                metodo.instrumentoId == instrumentoPrincipal.id;
+
+            final mesmoNome =
+                metodo.instrumentoNome != null &&
+                metodo.instrumentoNome!.trim().toLowerCase() ==
+                    instrumentoPrincipal.nome.trim().toLowerCase();
+
+            return mesmoId || mesmoNome;
+          }).toList()
+          ..sort(
+            (a, b) => a.nome.toLowerCase().compareTo(b.nome.toLowerCase()),
+          );
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.menu_book),
+            title: const Text('Métodos do instrumento principal'),
+            subtitle: Text(
+              instrumentoPrincipal == null
+                  ? 'Instrumento principal não informado'
+                  : 'Instrumento principal: ${instrumentoPrincipal.nome}',
+            ),
+          ),
+          if (instrumentoPrincipal == null)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Text('Nenhum instrumento principal informado.'),
+            )
+          else if (metodos.isEmpty)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Text(
+                'Nenhum método informado para o instrumento principal.',
+              ),
+            )
+          else
+            ...metodos.map(
+              (metodo) => ListTile(
+                dense: true,
+                leading: const Icon(Icons.book_outlined),
+                title: Text(metodo.nome),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/lib/views/aluno_detail/aluno_detail_page.dart
+++ b/frontend/lib/views/aluno_detail/aluno_detail_page.dart
@@ -140,6 +140,8 @@ class _AlunoDetailPageState extends State<AlunoDetailPage> {
                   valor: alunoAtual.comumUF ?? 'Não informado',
                   icone: Icons.map,
                 ),
+                _InstrumentosCard(aluno: alunoAtual),
+                _MetodosCard(aluno: alunoAtual),
                 const SizedBox(height: 16),
                 ElevatedButton.icon(
                   onPressed: editarAluno,
@@ -148,6 +150,96 @@ class _AlunoDetailPageState extends State<AlunoDetailPage> {
                 ),
               ],
             ),
+    );
+  }
+}
+
+class _InstrumentosCard extends StatelessWidget {
+  final Aluno aluno;
+
+  const _InstrumentosCard({required this.aluno});
+
+  @override
+  Widget build(BuildContext context) {
+    final instrumentos = [...aluno.instrumentos]
+      ..sort((a, b) {
+        if (a.principal == b.principal) {
+          return a.nome.toLowerCase().compareTo(b.nome.toLowerCase());
+        }
+        return a.principal ? -1 : 1;
+      });
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const ListTile(
+            leading: Icon(Icons.music_note),
+            title: Text('Instrumentos'),
+          ),
+          if (instrumentos.isEmpty)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Text('Nenhum instrumento informado.'),
+            )
+          else
+            ...instrumentos.map(
+              (instrumento) => ListTile(
+                dense: true,
+                leading: Icon(
+                  instrumento.principal ? Icons.star : Icons.music_note,
+                  color: instrumento.principal
+                      ? Theme.of(context).colorScheme.primary
+                      : null,
+                ),
+                title: Text(instrumento.nome),
+                trailing: instrumento.principal
+                    ? const Chip(label: Text('Principal'))
+                    : null,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetodosCard extends StatelessWidget {
+  final Aluno aluno;
+
+  const _MetodosCard({required this.aluno});
+
+  @override
+  Widget build(BuildContext context) {
+    final metodos = [...aluno.metodos]
+      ..sort((a, b) => a.nome.toLowerCase().compareTo(b.nome.toLowerCase()));
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const ListTile(
+            leading: Icon(Icons.menu_book),
+            title: Text('Métodos em estudo'),
+          ),
+          if (metodos.isEmpty)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Text('Nenhum método informado.'),
+            )
+          else
+            ...metodos.map(
+              (metodo) => ListTile(
+                dense: true,
+                leading: const Icon(Icons.book_outlined),
+                title: Text(metodo.nome),
+                subtitle: Text(metodo.instrumentoTexto),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/lib/views/aluno_detail/aluno_detail_page.dart
+++ b/frontend/lib/views/aluno_detail/aluno_detail_page.dart
@@ -212,22 +212,39 @@ class _MetodosCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final metodos = [...aluno.metodos]
-      ..sort((a, b) => a.nome.toLowerCase().compareTo(b.nome.toLowerCase()));
+    final instrumentoPrincipal = aluno.instrumentoPrincipal;
+    final metodos =
+        aluno.metodos
+            .where(
+              (metodo) =>
+                  instrumentoPrincipal != null &&
+                  metodo.instrumentoId == instrumentoPrincipal.id,
+            )
+            .toList()
+          ..sort(
+            (a, b) => a.nome.toLowerCase().compareTo(b.nome.toLowerCase()),
+          );
 
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const ListTile(
-            leading: Icon(Icons.menu_book),
-            title: Text('Métodos em estudo'),
+          ListTile(
+            leading: const Icon(Icons.menu_book),
+            title: const Text('Métodos em estudo'),
+            subtitle: instrumentoPrincipal == null
+                ? const Text('Instrumento principal não definido')
+                : Text('Instrumento principal: ${instrumentoPrincipal.nome}'),
           ),
           if (metodos.isEmpty)
-            const Padding(
-              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
-              child: Text('Nenhum método informado.'),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Text(
+                instrumentoPrincipal == null
+                    ? 'Defina o instrumento principal para visualizar os métodos.'
+                    : 'Nenhum método informado para o instrumento principal.',
+              ),
             )
           else
             ...metodos.map(

--- a/frontend/lib/views/aluno_form/aluno_form_page.dart
+++ b/frontend/lib/views/aluno_form/aluno_form_page.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 
 import '../../models/aluno.dart';
+import '../../models/instrumento.dart';
+import '../../models/metodo.dart';
 import '../../models/pessoa.dart';
 import '../../services/aluno_service.dart';
+import '../../services/instrumento_service.dart';
+import '../../services/metodo_service.dart';
 import '../../services/pessoa_service.dart';
 import '../../widgets/searchable_selection.dart';
 
@@ -19,11 +23,18 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
   final _formKey = GlobalKey<FormState>();
   final AlunoService service = AlunoService();
   final PessoaService pessoaService = PessoaService();
+  final InstrumentoService instrumentoService = InstrumentoService();
+  final MetodoService metodoService = MetodoService();
 
   final TextEditingController senhaController = TextEditingController();
 
   List<Pessoa> pessoas = [];
+  List<Instrumento> instrumentos = [];
+  List<Metodo> metodos = [];
+  final Set<int> instrumentoIdsSelecionados = {};
+  final Set<int> metodoIdsSelecionados = {};
   String? cpfSelecionado;
+  int? instrumentoPrincipalId;
 
   bool loading = true;
   bool salvando = false;
@@ -31,15 +42,26 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
 
   bool get isEdicao => widget.aluno != null;
 
+  List<Metodo> get metodosDoInstrumentoPrincipal {
+    final principalId = instrumentoPrincipalId;
+    if (principalId == null) return [];
+    return metodos
+        .where((metodo) => metodo.instrumentoId == principalId)
+        .toList();
+  }
+
+  int get quantidadeMetodosPreservados {
+    final idsVisiveis = metodosDoInstrumentoPrincipal
+        .map((metodo) => metodo.id)
+        .toSet();
+    return metodoIdsSelecionados.difference(idsVisiveis).length;
+  }
+
   @override
   void initState() {
     super.initState();
-
-    if (widget.aluno != null) {
-      cpfSelecionado = widget.aluno!.cpf;
-    }
-
-    carregarPessoas();
+    cpfSelecionado = widget.aluno?.cpf;
+    carregarDados();
   }
 
   @override
@@ -48,15 +70,37 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
     super.dispose();
   }
 
-  Future<void> carregarPessoas() async {
+  Future<void> carregarDados() async {
     try {
-      final lista = await pessoaService.getPessoas();
+      final requisicoes = <Future<dynamic>>[
+        pessoaService.getPessoas(),
+        instrumentoService.getInstrumentos(),
+        metodoService.getMetodos(),
+        if (isEdicao) service.getAlunoById(widget.aluno!.id),
+      ];
+      final resultados = await Future.wait(requisicoes);
+      final alunoAtual = isEdicao ? resultados[3] as Aluno : null;
 
+      if (!mounted) return;
       setState(() {
-        pessoas = lista;
+        pessoas = resultados[0] as List<Pessoa>;
+        instrumentos = resultados[1] as List<Instrumento>;
+        metodos = resultados[2] as List<Metodo>;
+
+        if (alunoAtual != null) {
+          cpfSelecionado = alunoAtual.cpf;
+          instrumentoIdsSelecionados.addAll(
+            alunoAtual.instrumentos.map((instrumento) => instrumento.id),
+          );
+          instrumentoPrincipalId = alunoAtual.instrumentoPrincipal?.id;
+          metodoIdsSelecionados.addAll(
+            alunoAtual.metodos.map((metodo) => metodo.id),
+          );
+        }
         loading = false;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         erro = e.toString();
         loading = false;
@@ -68,9 +112,17 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
     if (!_formKey.currentState!.validate()) return;
 
     if (cpfSelecionado == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Selecione uma pessoa')));
+      _mostrarMensagem('Selecione uma pessoa.');
+      return;
+    }
+    if (instrumentoIdsSelecionados.isEmpty) {
+      _mostrarMensagem('Selecione pelo menos um instrumento.');
+      return;
+    }
+    final principalId = instrumentoPrincipalId;
+    if (principalId == null ||
+        !instrumentoIdsSelecionados.contains(principalId)) {
+      _mostrarMensagem('Defina o instrumento principal do aluno.');
       return;
     }
 
@@ -84,11 +136,17 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
           id: widget.aluno!.id,
           cpf: cpfSelecionado!,
           senha: senhaController.text.trim(),
+          instrumentoIds: instrumentoIdsSelecionados,
+          instrumentoPrincipalId: principalId,
+          metodoIds: metodoIdsSelecionados,
         );
       } else {
         await service.criarAluno(
           cpf: cpfSelecionado!,
           senha: senhaController.text.trim(),
+          instrumentoIds: instrumentoIdsSelecionados,
+          instrumentoPrincipalId: principalId,
+          metodoIds: metodoIdsSelecionados,
         );
       }
 
@@ -96,10 +154,7 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
       Navigator.pop(context, true);
     } catch (e) {
       if (!mounted) return;
-
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Erro ao salvar: $e')));
+      _mostrarMensagem('Erro ao salvar: $e');
     } finally {
       if (mounted) {
         setState(() {
@@ -109,29 +164,43 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
     }
   }
 
+  void _mostrarMensagem(String mensagem) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(mensagem)));
+  }
+
+  void _alternarInstrumento(int instrumentoId, bool selecionado) {
+    setState(() {
+      if (selecionado) {
+        instrumentoIdsSelecionados.add(instrumentoId);
+        instrumentoPrincipalId ??= instrumentoId;
+      } else {
+        instrumentoIdsSelecionados.remove(instrumentoId);
+        if (instrumentoPrincipalId == instrumentoId) {
+          instrumentoPrincipalId = instrumentoIdsSelecionados.isEmpty
+              ? null
+              : instrumentoIdsSelecionados.first;
+        }
+      }
+    });
+  }
+
   String? validarSenha(String? value) {
     final senha = value?.trim() ?? '';
-
-    if (!isEdicao && senha.isEmpty) {
-      return 'Informe a senha';
-    }
-
+    if (!isEdicao && senha.isEmpty) return 'Informe a senha';
     if (senha.isNotEmpty && senha.length > 16) {
       return 'Senha deve ter no máximo 16 caracteres';
     }
-
     return null;
   }
 
-  String textoPessoa(Pessoa pessoa) {
-    return '${pessoa.nome} - ${pessoa.cpf}';
-  }
+  String textoPessoa(Pessoa pessoa) => '${pessoa.nome} - ${pessoa.cpf}';
 
   Pessoa? pessoaSelecionada() {
     for (final pessoa in pessoas) {
       if (pessoa.cpf == cpfSelecionado) return pessoa;
     }
-
     return null;
   }
 
@@ -148,64 +217,193 @@ class _AlunoFormPageState extends State<AlunoFormPage> {
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: Text(
-                  'Erro ao carregar pessoas:\n$erro',
+                  'Erro ao carregar dados do formulário:\n$erro',
                   textAlign: TextAlign.center,
                 ),
               ),
             )
-          : Padding(
-              padding: const EdgeInsets.all(16),
-              child: Form(
-                key: _formKey,
-                child: ListView(
-                  children: [
-                    SearchableSelectionField<Pessoa>(
-                      labelText: 'Pessoa',
-                      dialogTitle: 'Selecionar pessoa',
-                      items: pessoas,
-                      value: pessoaSelecionada(),
-                      itemTitle: textoPessoa,
-                      itemSubtitle: (pessoa) => pessoa.comumCompleta,
-                      itemSearchText: (pessoa) =>
-                          '${pessoa.nome} ${pessoa.cpf} ${pessoa.comumCompleta}',
-                      searchHintText: 'Buscar por nome, CPF ou comum...',
-                      onChanged: (pessoa) {
-                        setState(() {
-                          cpfSelecionado = pessoa?.cpf;
-                        });
-                      },
-                      validator: (value) {
-                        if (value == null) {
-                          return 'Selecione uma pessoa';
-                        }
-                        return null;
-                      },
+          : Form(
+              key: _formKey,
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  _buildDadosPessoais(),
+                  const SizedBox(height: 24),
+                  _buildInstrumentos(),
+                  const SizedBox(height: 24),
+                  _buildMetodos(),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: salvando ? null : salvar,
+                    child: Text(
+                      salvando
+                          ? 'Salvando...'
+                          : isEdicao
+                          ? 'Salvar alterações'
+                          : 'Cadastrar',
                     ),
-                    const SizedBox(height: 16),
-                    TextFormField(
-                      controller: senhaController,
-                      obscureText: true,
-                      decoration: InputDecoration(
-                        labelText: isEdicao ? 'Nova senha (opcional)' : 'Senha',
-                        border: const OutlineInputBorder(),
-                      ),
-                      validator: validarSenha,
-                    ),
-                    const SizedBox(height: 24),
-                    ElevatedButton(
-                      onPressed: salvando ? null : salvar,
-                      child: Text(
-                        salvando
-                            ? 'Salvando...'
-                            : isEdicao
-                            ? 'Salvar alterações'
-                            : 'Cadastrar',
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
+    );
+  }
+
+  Widget _buildDadosPessoais() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Dados do aluno', style: Theme.of(context).textTheme.titleLarge),
+        const SizedBox(height: 12),
+        SearchableSelectionField<Pessoa>(
+          labelText: 'Pessoa',
+          dialogTitle: 'Selecionar pessoa',
+          items: pessoas,
+          value: pessoaSelecionada(),
+          itemTitle: textoPessoa,
+          itemSubtitle: (pessoa) => pessoa.comumCompleta,
+          itemSearchText: (pessoa) =>
+              '${pessoa.nome} ${pessoa.cpf} ${pessoa.comumCompleta}',
+          searchHintText: 'Buscar por nome, CPF ou comum...',
+          onChanged: (pessoa) {
+            setState(() {
+              cpfSelecionado = pessoa?.cpf;
+            });
+          },
+          validator: (value) => value == null ? 'Selecione uma pessoa' : null,
+        ),
+        const SizedBox(height: 16),
+        TextFormField(
+          controller: senhaController,
+          obscureText: true,
+          decoration: InputDecoration(
+            labelText: isEdicao ? 'Nova senha (opcional)' : 'Senha',
+            border: const OutlineInputBorder(),
+          ),
+          validator: validarSenha,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInstrumentos() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Instrumentos', style: Theme.of(context).textTheme.titleLarge),
+        const SizedBox(height: 4),
+        const Text(
+          'Selecione os instrumentos do aluno e marque exatamente um como principal.',
+        ),
+        const SizedBox(height: 8),
+        if (instrumentos.isEmpty)
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('Nenhum instrumento cadastrado.'),
+            ),
+          )
+        else
+          Card(
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              children: instrumentos.map((instrumento) {
+                final selecionado = instrumentoIdsSelecionados.contains(
+                  instrumento.id,
+                );
+                final principal = instrumentoPrincipalId == instrumento.id;
+
+                return ListTile(
+                  onTap: () =>
+                      _alternarInstrumento(instrumento.id, !selecionado),
+                  leading: Checkbox(
+                    value: selecionado,
+                    onChanged: (value) =>
+                        _alternarInstrumento(instrumento.id, value ?? false),
+                  ),
+                  title: Text(instrumento.nome),
+                  subtitle: principal
+                      ? const Text('Instrumento principal')
+                      : null,
+                  trailing: IconButton(
+                    onPressed: selecionado
+                        ? () {
+                            setState(() {
+                              instrumentoPrincipalId = instrumento.id;
+                            });
+                          }
+                        : null,
+                    tooltip: principal
+                        ? 'Instrumento principal'
+                        : 'Definir como principal',
+                    icon: Icon(
+                      principal
+                          ? Icons.radio_button_checked
+                          : Icons.radio_button_unchecked,
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildMetodos() {
+    final metodosVisiveis = metodosDoInstrumentoPrincipal;
+    final principal = instrumentos
+        .where((instrumento) => instrumento.id == instrumentoPrincipalId)
+        .firstOrNull;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Métodos', style: Theme.of(context).textTheme.titleLarge),
+        const SizedBox(height: 4),
+        Text(
+          principal == null
+              ? 'Defina o instrumento principal para escolher os métodos.'
+              : 'Métodos disponíveis para ${principal.nome}.',
+        ),
+        if (quantidadeMetodosPreservados > 0) ...[
+          const SizedBox(height: 4),
+          Text(
+            '$quantidadeMetodosPreservados método(s) de outros instrumentos serão preservados.',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+        const SizedBox(height: 8),
+        if (principal != null && metodosVisiveis.isEmpty)
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('Nenhum método cadastrado para este instrumento.'),
+            ),
+          )
+        else if (metodosVisiveis.isNotEmpty)
+          Card(
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              children: metodosVisiveis.map((metodo) {
+                return CheckboxListTile(
+                  value: metodoIdsSelecionados.contains(metodo.id),
+                  title: Text(metodo.nome),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  onChanged: (selecionado) {
+                    setState(() {
+                      if (selecionado == true) {
+                        metodoIdsSelecionados.add(metodo.id);
+                      } else {
+                        metodoIdsSelecionados.remove(metodo.id);
+                      }
+                    });
+                  },
+                );
+              }).toList(),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.1.0"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## Descrição

Esta PR complementa a issue #134, exibindo no perfil do aluno as informações relacionadas aos instrumentos e métodos vinculados ao seu cadastro.

Agora, ao acessar a tela **Meu perfil**, o aluno consegue visualizar os instrumentos que toca, com destaque para o instrumento principal, além dos métodos associados a esse instrumento principal.

## Alterações realizadas

* Adicionada a seção **Instrumentos que toca** no perfil do aluno.
* Exibido o instrumento principal com destaque visual.
* Ordenados os instrumentos para que o principal apareça primeiro.
* Adicionada a seção **Métodos do instrumento principal**.
* Filtrados os métodos exibidos para mostrar apenas aqueles vinculados ao instrumento principal.
* Adicionado fallback para identificar o instrumento do método tanto por `instrumentoId` quanto por `instrumentoNome`.

## Arquivo alterado

* `frontend/lib/views/aluno_area/aluno_perfil_page.dart`

## Testes realizados

* Acessado o perfil do aluno.
* Verificado que os instrumentos do aluno aparecem corretamente.
* Verificado que o instrumento principal aparece destacado.
* Verificado que os métodos exibidos correspondem ao instrumento principal.
* Verificado comportamento quando o aluno não possui instrumentos, instrumento principal ou métodos cadastrados.

## Observação

A alteração aproveita os dados que já estavam sendo retornados no modelo `Aluno`, sem modificar regras de negócio ou endpoints do backend.

Closes #134 